### PR TITLE
feat: add concise status output (--short)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ fw --worklist
 
 # Schema for query output
 fw --schema
+
+# Tight status snapshot
+fw status --short
 ```
 
 Tip: running `fw` in a repo auto-syncs if there's no cache yet, then runs your query. For a fresh session, `fw --worklist` keeps the output minimal.
@@ -83,6 +86,15 @@ Print JSON schema hints for query outputs.
 fw schema
 fw schema entry
 fw schema worklist
+```
+
+### status
+
+Summarize PR activity.
+
+```bash
+fw status
+fw status --short
 ```
 
 ## Configuration
@@ -150,13 +162,11 @@ fw schema worklist
 
 ## Short Status Snapshot
 
-Firewatch doesn't ship a `status` command yet, but the worklist makes it easy to keep output tight:
+`fw status --short` is a tight, per-PR snapshot:
 
 ```bash
-fw query --worklist | jq '{repo, pr, pr_title, pr_state, changes_requested: .review_states.changes_requested, comments: .counts.comments}'
+fw status --short
 ```
-
-The plan is to add `fw status --short` as a thin wrapper over this view.
 
 ## Planned Write Ops
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -246,18 +246,12 @@ fw schema entry                   # Entry schema (JSON)
 fw schema worklist                # Worklist schema (JSON)
 ```
 
-### status (planned)
+### status
 
 Tight per-PR summary with minimal context:
 
 ```bash
 fw status --short
-```
-
-Until that exists, build it from the worklist:
-
-```bash
-fw query --worklist | jq '{repo, pr, pr_title, pr_state, changes_requested: .review_states.changes_requested, comments: .counts.comments}'
 ```
 
 ### comment (planned)
@@ -291,7 +285,7 @@ fw query | jq -r '[.repo, .pr, .type, .author, .created_at] | @csv'
 fw query --type review | jq 'select(.graphite.stack_id == "feat-auth")'
 
 # Short status snapshot (worklist)
-fw query --worklist | jq '{repo, pr, pr_title, pr_state, changes_requested: .review_states.changes_requested, comments: .counts.comments}'
+fw status --short
 ```
 
 ## Authentication

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -1,0 +1,113 @@
+import {
+  type FirewatchConfig,
+  type PrState,
+  loadConfig,
+  parseSince,
+  queryEntries,
+} from "@outfitter/firewatch-core";
+import { Command } from "commander";
+
+import { outputStatusShort } from "../status";
+import { outputWorklist } from "../worklist";
+
+/**
+ * Parse comma-separated state values.
+ */
+function parseStates(value: string): PrState[] {
+  return value.split(",").map((s) => s.trim() as PrState);
+}
+
+interface StatusCommandOptions {
+  repo?: string;
+  pr?: number;
+  state?: string;
+  open?: boolean;
+  draft?: boolean;
+  active?: boolean;
+  label?: string;
+  since?: string;
+  short?: boolean;
+}
+
+function resolveStates(
+  options: StatusCommandOptions,
+  config: FirewatchConfig
+): PrState[] | undefined {
+  if (options.state) {
+    return parseStates(options.state);
+  }
+  if (options.active) {
+    return ["open", "draft"];
+  }
+  if (options.open && options.draft) {
+    return ["open", "draft"];
+  }
+  if (options.open) {
+    return ["open"];
+  }
+  if (options.draft) {
+    return ["draft"];
+  }
+  return config.default_states ?? ["open", "draft"];
+}
+
+function buildStatusQueryOptions(
+  options: StatusCommandOptions,
+  config: FirewatchConfig
+) {
+  const states = resolveStates(options, config);
+  const since = options.since ?? config.default_since;
+
+  return {
+    filters: {
+      ...(options.repo && { repo: options.repo }),
+      ...(options.pr !== undefined && { pr: options.pr }),
+      ...(states && { states }),
+      ...(options.label && { label: options.label }),
+      ...(since && { since: parseSince(since) }),
+    },
+    plugins: [],
+  };
+}
+
+export const statusCommand = new Command("status")
+  .description("Summarize PR activity")
+  .option("--repo <name>", "Filter by repository (partial match)")
+  .option("--pr <number>", "Filter by PR number", Number.parseInt)
+  .option(
+    "--state <states>",
+    "Filter by PR state (comma-separated: open,closed,merged,draft)"
+  )
+  .option("--open", "Shorthand for --state open")
+  .option("--draft", "Shorthand for --state draft")
+  .option("--active", "Shorthand for --state open,draft")
+  .option("--label <name>", "Filter by PR label (partial match)")
+  .option("--since <duration>", "Filter by time (e.g., 24h, 7d)")
+  .option("--short", "Tight per-PR summary output")
+  .action(async (options: StatusCommandOptions) => {
+    try {
+      const config = await loadConfig();
+      const entries = await queryEntries(
+        buildStatusQueryOptions(options, config)
+      );
+
+      if (options.short) {
+        const wrote = await outputStatusShort(entries);
+        if (!wrote) {
+          console.error("No entries found for status.");
+        }
+        return;
+      }
+
+      const wrote = await outputWorklist(entries);
+      if (!wrote) {
+        console.error("No entries found for status.");
+      }
+    } catch (error) {
+      console.error(
+        "Status failed:",
+        error instanceof Error ? error.message : error
+      );
+      process.exit(1);
+    }
+  });

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -23,6 +23,7 @@ import ora from "ora";
 
 import { configCommand } from "./commands/config";
 import { queryCommand } from "./commands/query";
+import { statusCommand } from "./commands/status";
 import { printSchema, schemaCommand } from "./commands/schema";
 import { syncCommand } from "./commands/sync";
 import { outputStackedEntries } from "./stack";
@@ -247,6 +248,7 @@ program
 
 program.addCommand(syncCommand);
 program.addCommand(queryCommand);
+program.addCommand(statusCommand);
 program.addCommand(lookoutCommand);
 program.addCommand(configCommand);
 program.addCommand(schemaCommand);

--- a/apps/cli/src/status.ts
+++ b/apps/cli/src/status.ts
@@ -1,0 +1,69 @@
+import {
+  buildWorklist,
+  sortWorklist,
+  type FirewatchEntry,
+  type WorklistEntry,
+} from "@outfitter/firewatch-core";
+import type { GraphiteStack } from "@outfitter/firewatch-core/plugins";
+
+import { ensureGraphiteMetadata } from "./stack";
+
+export interface StatusShortEntry {
+  repo: string;
+  pr: number;
+  pr_title: string;
+  pr_state: string;
+  pr_author: string;
+  last_activity_at: string;
+  comments: number;
+  changes_requested: number;
+  stack_id?: string;
+  stack_position?: number;
+}
+
+export function formatStatusShort(item: WorklistEntry): StatusShortEntry {
+  const short: StatusShortEntry = {
+    repo: item.repo,
+    pr: item.pr,
+    pr_title: item.pr_title,
+    pr_state: item.pr_state,
+    pr_author: item.pr_author,
+    last_activity_at: item.last_activity_at,
+    comments: item.counts.comments,
+    changes_requested: item.review_states?.changes_requested ?? 0,
+  };
+
+  if (item.graphite?.stack_id) {
+    short.stack_id = item.graphite.stack_id;
+    if (item.graphite.stack_position !== undefined) {
+      short.stack_position = item.graphite.stack_position;
+    }
+  }
+
+  return short;
+}
+
+export async function buildStatusShort(
+  entries: FirewatchEntry[],
+  options: { stacks?: GraphiteStack[] | null } = {}
+): Promise<StatusShortEntry[]> {
+  const enriched = await ensureGraphiteMetadata(entries, options);
+  const worklist = sortWorklist(buildWorklist(enriched));
+  return worklist.map(formatStatusShort);
+}
+
+export async function outputStatusShort(
+  entries: FirewatchEntry[],
+  options: { stacks?: GraphiteStack[] | null } = {}
+): Promise<boolean> {
+  const items = await buildStatusShort(entries, options);
+  if (items.length === 0) {
+    return false;
+  }
+
+  for (const item of items) {
+    console.log(JSON.stringify(item));
+  }
+
+  return true;
+}

--- a/apps/cli/tests/status.test.ts
+++ b/apps/cli/tests/status.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "bun:test";
+
+import type { FirewatchEntry } from "@outfitter/firewatch-core";
+import { outputStatusShort } from "../src/status";
+
+test("outputStatusShort emits a tight per-PR summary", async () => {
+  const entries: FirewatchEntry[] = [
+    {
+      id: "comment-1",
+      repo: "outfitter-dev/firewatch",
+      pr: 10,
+      pr_title: "Base",
+      pr_state: "open",
+      pr_author: "alice",
+      pr_branch: "base",
+      type: "comment",
+      author: "alice",
+      created_at: "2025-01-02T03:00:00.000Z",
+      captured_at: "2025-01-02T04:00:00.000Z",
+      graphite: {
+        stack_id: "feat-auth",
+        stack_position: 1,
+        stack_size: 2,
+      },
+    },
+    {
+      id: "review-1",
+      repo: "outfitter-dev/firewatch",
+      pr: 10,
+      pr_title: "Base",
+      pr_state: "open",
+      pr_author: "alice",
+      pr_branch: "base",
+      type: "review",
+      author: "bob",
+      state: "changes_requested",
+      created_at: "2025-01-02T03:10:00.000Z",
+      captured_at: "2025-01-02T04:00:00.000Z",
+      graphite: {
+        stack_id: "feat-auth",
+        stack_position: 1,
+        stack_size: 2,
+      },
+    },
+    {
+      id: "comment-2",
+      repo: "outfitter-dev/firewatch",
+      pr: 11,
+      pr_title: "Follow-up",
+      pr_state: "open",
+      pr_author: "bob",
+      pr_branch: "follow",
+      type: "comment",
+      author: "bob",
+      created_at: "2025-01-02T03:05:00.000Z",
+      captured_at: "2025-01-02T04:00:00.000Z",
+      graphite: {
+        stack_id: "feat-auth",
+        stack_position: 2,
+        stack_size: 2,
+      },
+    },
+  ];
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (value?: unknown) => {
+    logs.push(String(value));
+  };
+
+  try {
+    const wrote = await outputStatusShort(entries);
+    expect(wrote).toBe(true);
+  } finally {
+    console.log = originalLog;
+  }
+
+  expect(logs).toHaveLength(2);
+
+  const first = JSON.parse(logs[0]!);
+  expect(first.pr).toBe(10);
+  expect(first.comments).toBe(1);
+  expect(first.changes_requested).toBe(1);
+  expect(first.stack_id).toBe("feat-auth");
+  expect(first.stack_position).toBe(1);
+
+  const second = JSON.parse(logs[1]!);
+  expect(second.pr).toBe(11);
+  expect(second.comments).toBe(1);
+  expect(second.changes_requested).toBe(0);
+  expect(second.stack_position).toBe(2);
+});

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -142,13 +142,11 @@ The JSONL records are denormalized, so each line includes PR context plus the sp
 
 ## Short Status Snapshot
 
-If you want an ultra-tight status view, build it off the worklist:
+If you want an ultra-tight status view, use:
 
 ```bash
-fw query --worklist | jq '{repo, pr, pr_title, pr_state, changes_requested: .review_states.changes_requested, comments: .counts.comments}'
+fw status --short
 ```
-
-Planned: `fw status --short` will be a thin wrapper over this view.
 
 ## Write Ops (Planned)
 


### PR DESCRIPTION
## Summary
- Add `fw status --short` to emit a tight per-PR status JSONL payload.
- Include counts for comments and changes requested plus last activity timestamp.
- Preserve optional Graphite stack identifiers in short output.

## Testing
- bun run test
- bun run check
