### PR TITLE
feat: add comment + resolve commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,26 @@ fw status
 fw status --short
 ```
 
+### comment
+
+Post a PR comment or reply to a review thread.
+
+```bash
+# Top-level PR comment
+fw comment 42 "Addressed feedback"
+
+# Reply and resolve
+fw comment 42 "Fixed in abc123" --reply-to comment-2001 --resolve
+```
+
+### resolve
+
+Resolve review comment threads by comment ID.
+
+```bash
+fw resolve comment-2001 comment-2002
+```
+
 ## Configuration
 
 Firewatch loads configuration in this order (project overrides user):
@@ -168,13 +188,13 @@ fw schema worklist
 fw status --short
 ```
 
-## Planned Write Ops
+## Write Ops
 
-To close the loop on feedback, the plan is to add write commands:
+Firewatch can post replies and resolve review threads so agents can close the loop:
 
 ```bash
-# Post a comment and resolve in one step
 fw comment 42 "Fixed in abc123" --reply-to comment-2001 --resolve
+fw resolve comment-2001 comment-2002
 ```
 
 ## Development

--- a/SPEC.md
+++ b/SPEC.md
@@ -254,12 +254,20 @@ Tight per-PR summary with minimal context:
 fw status --short
 ```
 
-### comment (planned)
+### comment
 
 Post a comment and optionally resolve in one step:
 
 ```bash
 fw comment 42 "Fixed in abc123" --reply-to comment-2001 --resolve
+```
+
+### resolve
+
+Resolve review comment threads by comment ID:
+
+```bash
+fw resolve comment-2001 comment-2002
 ```
 
 ## Example jq Workflows

--- a/apps/cli/src/commands/comment.ts
+++ b/apps/cli/src/commands/comment.ts
@@ -1,0 +1,113 @@
+import {
+  GitHubClient,
+  detectAuth,
+  detectRepo,
+  loadConfig,
+} from "@outfitter/firewatch-core";
+import { Command } from "commander";
+
+import { parseRepoInput } from "../repo";
+
+interface CommentCommandOptions {
+  repo?: string;
+  replyTo?: string;
+  resolve?: boolean;
+}
+
+async function resolveRepo(repo?: string): Promise<string> {
+  if (repo) {
+    return repo;
+  }
+
+  const detected = await detectRepo();
+  if (detected.repo) {
+    console.error(`Detected ${detected.repo} from ${detected.source}`);
+    return detected.repo;
+  }
+
+  throw new Error(
+    "No repository detected. Use: fw comment --repo owner/repo"
+  );
+}
+
+export const commentCommand = new Command("comment")
+  .description("Post a PR comment or reply to a review thread")
+  .argument("<pr>", "PR number", Number.parseInt)
+  .argument("<body>", "Comment body")
+  .option("--repo <name>", "Repository (owner/repo format)")
+  .option("--reply-to <commentId>", "Reply to a review comment")
+  .option("--resolve", "Resolve the review thread after replying")
+  .action(
+    async (
+      pr: number,
+      body: string,
+      options: CommentCommandOptions
+    ) => {
+      try {
+        if (options.resolve && !options.replyTo) {
+          console.error("--resolve requires --reply-to.");
+          process.exit(1);
+        }
+
+        const config = await loadConfig();
+        const repo = await resolveRepo(options.repo);
+        const { owner, name } = parseRepoInput(repo);
+
+        const auth = await detectAuth(config.github_token);
+        if (!auth.token) {
+          console.error(auth.error);
+          process.exit(1);
+        }
+
+        const client = new GitHubClient(auth.token);
+
+        if (options.replyTo) {
+          const threadMap = await client.fetchReviewThreadMap(owner, name, pr);
+          const threadId = threadMap.get(options.replyTo);
+          if (!threadId) {
+            console.error(
+              `No review thread found for comment ${options.replyTo}.`
+            );
+            process.exit(1);
+          }
+
+          const reply = await client.addReviewThreadReply(threadId, body);
+          if (options.resolve) {
+            await client.resolveReviewThread(threadId);
+          }
+
+          console.log(
+            JSON.stringify({
+              ok: true,
+              repo,
+              pr,
+              comment_id: reply.id,
+              reply_to: options.replyTo,
+              ...(options.resolve && { resolved: true }),
+              ...(reply.url && { url: reply.url }),
+            })
+          );
+          return;
+        }
+
+        const prId = await client.fetchPullRequestId(owner, name, pr);
+        const comment = await client.addIssueComment(prId, body);
+
+        console.log(
+          JSON.stringify({
+            ok: true,
+            repo,
+            pr,
+            comment_id: comment.id,
+            ...(comment.url && { url: comment.url }),
+          })
+        );
+      } catch (error) {
+        console.error(
+          "Comment failed:",
+          error instanceof Error ? error.message : error
+        );
+        process.exit(1);
+      }
+    }
+  );

--- a/apps/cli/src/commands/resolve.ts
+++ b/apps/cli/src/commands/resolve.ts
@@ -1,0 +1,174 @@
+import {
+  GitHubClient,
+  detectAuth,
+  loadConfig,
+  queryEntries,
+} from "@outfitter/firewatch-core";
+import { Command } from "commander";
+
+import { parseRepoInput } from "../repo";
+
+interface ResolveCommandOptions {
+  repo?: string;
+  pr?: number;
+}
+
+interface ResolveTarget {
+  repo: string;
+  pr: number;
+  commentId: string;
+}
+
+type LookupResult = { target: ResolveTarget } | { error: string };
+
+async function lookupTarget(commentId: string): Promise<LookupResult> {
+  const entries = await queryEntries({ filters: { id: commentId } });
+  const entry = entries[0];
+  if (!entry) {
+    return {
+      error: `Comment ${commentId} not found in cache. Run fw sync or pass --repo and --pr.`,
+    };
+  }
+
+  if (entry.type !== "comment" || entry.subtype !== "review_comment") {
+    return {
+      error: `Comment ${commentId} is not a review comment thread entry.`,
+    };
+  }
+
+  return { target: { repo: entry.repo, pr: entry.pr, commentId } };
+}
+
+async function collectTargets(
+  commentIds: string[],
+  options: ResolveCommandOptions
+): Promise<{ targets: ResolveTarget[]; hadError: boolean }> {
+  const targets: ResolveTarget[] = [];
+  let hadError = false;
+
+  if (options.repo && options.pr !== undefined) {
+    for (const commentId of commentIds) {
+      targets.push({ repo: options.repo, pr: options.pr, commentId });
+    }
+    return { targets, hadError };
+  }
+
+  for (const commentId of commentIds) {
+    const result = await lookupTarget(commentId);
+    if ("error" in result) {
+      console.error(result.error);
+      hadError = true;
+      continue;
+    }
+    targets.push(result.target);
+  }
+
+  return { targets, hadError };
+}
+
+async function createClient(): Promise<GitHubClient> {
+  const config = await loadConfig();
+  const auth = await detectAuth(config.github_token);
+  if (!auth.token) {
+    throw new Error(auth.error);
+  }
+  return new GitHubClient(auth.token);
+}
+
+function groupTargets(targets: ResolveTarget[]): Map<string, ResolveTarget[]> {
+  const grouped = new Map<string, ResolveTarget[]>();
+  for (const target of targets) {
+    const key = `${target.repo}#${target.pr}`;
+    const group = grouped.get(key) ?? [];
+    group.push(target);
+    grouped.set(key, group);
+  }
+  return grouped;
+}
+
+async function resolveTargets(
+  client: GitHubClient,
+  grouped: Map<string, ResolveTarget[]>
+): Promise<boolean> {
+  let hadError = false;
+
+  for (const group of grouped.values()) {
+    const { repo, pr } = group[0]!;
+    const { owner, name } = parseRepoInput(repo);
+    const threadMap = await client.fetchReviewThreadMap(owner, name, pr);
+    const resolvedThreads = new Set<string>();
+
+    for (const target of group) {
+      const threadId = threadMap.get(target.commentId);
+      if (!threadId) {
+        console.error(
+          `No review thread found for comment ${target.commentId} (repo ${repo} PR ${pr}).`
+        );
+        hadError = true;
+        continue;
+      }
+
+      if (!resolvedThreads.has(threadId)) {
+        await client.resolveReviewThread(threadId);
+        resolvedThreads.add(threadId);
+      }
+
+      console.log(
+        JSON.stringify({
+          ok: true,
+          repo,
+          pr,
+          comment_id: target.commentId,
+          thread_id: threadId,
+        })
+      );
+    }
+  }
+
+  return hadError;
+}
+
+export const resolveCommand = new Command("resolve")
+  .description("Resolve review comment threads")
+  .argument("<commentIds...>", "Review comment IDs to resolve")
+  .option("--repo <name>", "Repository (owner/repo format)")
+  .option("--pr <number>", "PR number", Number.parseInt)
+  .action(async (commentIds: string[], options: ResolveCommandOptions) => {
+    try {
+      if (commentIds.length === 0) {
+        console.error("No comment IDs provided.");
+        process.exit(1);
+      }
+
+      if (
+        (options.repo && options.pr === undefined) ||
+        (!options.repo && options.pr !== undefined)
+      ) {
+        console.error("--repo and --pr must be provided together.");
+        process.exit(1);
+      }
+
+      const { targets, hadError: lookupErrors } = await collectTargets(
+        commentIds,
+        options
+      );
+
+      if (targets.length === 0) {
+        process.exit(1);
+      }
+
+      const client = await createClient();
+      const grouped = groupTargets(targets);
+      const resolveErrors = await resolveTargets(client, grouped);
+
+      if (lookupErrors || resolveErrors) {
+        process.exit(1);
+      }
+    } catch (error) {
+      console.error(
+        "Resolve failed:",
+        error instanceof Error ? error.message : error
+      );
+      process.exit(1);
+    }
+  });

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -22,7 +22,9 @@ import { Command } from "commander";
 import ora from "ora";
 
 import { configCommand } from "./commands/config";
+import { commentCommand } from "./commands/comment";
 import { queryCommand } from "./commands/query";
+import { resolveCommand } from "./commands/resolve";
 import { statusCommand } from "./commands/status";
 import { printSchema, schemaCommand } from "./commands/schema";
 import { syncCommand } from "./commands/sync";
@@ -250,6 +252,8 @@ program.addCommand(syncCommand);
 program.addCommand(queryCommand);
 program.addCommand(statusCommand);
 program.addCommand(lookoutCommand);
+program.addCommand(commentCommand);
+program.addCommand(resolveCommand);
 program.addCommand(configCommand);
 program.addCommand(schemaCommand);
 

--- a/apps/cli/src/repo.ts
+++ b/apps/cli/src/repo.ts
@@ -1,0 +1,7 @@
+export function parseRepoInput(repo: string): { owner: string; name: string } {
+  const [owner, name] = repo.split("/");
+  if (!owner || !name) {
+    throw new Error(`Invalid repo format: ${repo}. Expected owner/repo`);
+  }
+  return { owner, name };
+}

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -148,12 +148,18 @@ If you want an ultra-tight status view, use:
 fw status --short
 ```
 
-## Write Ops (Planned)
+## Write Ops
 
-Closing the loop on feedback should be one command:
+Close the loop on feedback in one command:
 
 ```bash
 fw comment 42 "Fixed in abc123" --reply-to comment-2001 --resolve
+```
+
+Resolve review threads directly by comment ID:
+
+```bash
+fw resolve comment-2001 comment-2002
 ```
 
 ## Suggested Agent Prompts

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -13,6 +13,9 @@ import type { FirewatchEntry, PrState } from "./schema/entry";
  * Query filters.
  */
 export interface QueryFilters {
+  /** Filter by entry ID */
+  id?: string;
+
   /** Filter by repository (partial match) */
   repo?: string;
 
@@ -117,6 +120,10 @@ function matchesFilters(
   plugins: FirewatchPlugin[]
 ): boolean {
   if (filters.repo && !entry.repo.includes(filters.repo)) {
+    return false;
+  }
+
+  if (filters.id && entry.id !== filters.id) {
     return false;
   }
 

--- a/packages/core/tests/query.test.ts
+++ b/packages/core/tests/query.test.ts
@@ -96,6 +96,12 @@ test("queryEntries filters by repo substring", async () => {
   expect(results.every((entry) => entry.repo === repoA)).toBe(true);
 });
 
+test("queryEntries filters by id", async () => {
+  const results = await queryEntries({ filters: { id: "review-1" } });
+  expect(results).toHaveLength(1);
+  expect(results[0]?.id).toBe("review-1");
+});
+
 test("queryEntries filters by label and state", async () => {
   const results = await queryEntries({
     filters: { label: "BUG", states: ["open"] },


### PR DESCRIPTION
## Summary
- Add `fw comment` to post comments (with optional resolve) via GitHub GraphQL.
- Add `fw resolve` to resolve review threads by comment id.
- Allow query filtering by entry id for targeted operations.

## Testing
- bun run test
- bun run check
