### PR TITLE
feat: add stack file provenance + refine staleness

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ fw check
 fw check owner/repo
 ```
 
+When running inside a repo, Firewatch will use local git history to match commits to comment file paths for more accurate staleness hints.
+
 ### query
 
 Filter cached activity and print JSONL to stdout.
@@ -150,6 +152,7 @@ If the repo uses Graphite, Firewatch can enrich entries with stack metadata. Sta
 - Auto-detected when running inside a Graphite repo.
 - Enable by default in config with `graphite_enabled = true`.
 - Show grouped output with `--stack` (or `default_stack = true`).
+- Review comments can include `file_provenance` to show which PR in a stack last modified a file.
 
 Stack metadata is designed to be compatible with GitHub's stacked PRs as they roll out.
 
@@ -197,7 +200,7 @@ fw schema worklist
 fw status --short
 ```
 
-After running `fw check`, comment entries may include `file_activity_after` staleness hints.
+After running `fw check`, comment entries may include `file_activity_after` staleness hints. When commit file lists are available, the hints are scoped to the comment's file; otherwise they fall back to PR-level activity.
 
 ## Write Ops
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -174,9 +174,15 @@ interface FirewatchEntry {
   line?: number;
   file_activity_after?: {
     modified: boolean;
-    commits_touching_file: number;
+    commits_touching_file: number; // best-effort, file-scoped when file data is available
     latest_commit?: string;
     latest_commit_at?: string;
+  };
+  file_provenance?: {
+    origin_pr: number;
+    origin_branch: string;
+    origin_commit: string;
+    stack_position: number;
   };
 
   // Plugin data (optional)
@@ -223,6 +229,8 @@ Refresh staleness hints in the local cache.
 fw check
 fw check outfitter-dev/ranger
 ```
+
+When running inside a repo, Firewatch uses local git history to match commit file paths for more accurate staleness hints.
 
 ### query
 

--- a/apps/cli/src/commands/check.ts
+++ b/apps/cli/src/commands/check.ts
@@ -9,6 +9,8 @@ import {
 } from "@outfitter/firewatch-core";
 import { Command } from "commander";
 
+import { writeJsonLine } from "../utils/json";
+
 function resolveRepos(
   repo: string | undefined,
   configRepos: string[],
@@ -77,7 +79,7 @@ export const checkCommand = new Command("check")
         ) => client.getCommitFiles(owner, repoName, commitId);
 
         const result = await checkRepo(r, { resolveCommitFiles });
-        console.log(JSON.stringify(result));
+        await writeJsonLine(result);
       }
     } catch (error) {
       console.error(

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -36,7 +36,9 @@ Refresh staleness hints in the local cache:
 fw check
 ```
 
-After `fw check`, comment entries can include `file_activity_after` so you can see whether follow-up commits landed after the feedback.
+After `fw check`, comment entries can include `file_activity_after` so you can see whether follow-up commits landed after the feedback. When commit file lists are available, the hints are file-scoped; otherwise they fall back to PR-level activity.
+
+When running inside a repo, Firewatch uses local git history to match commit file paths for more accurate staleness hints.
 
 ## Query
 
@@ -107,9 +109,9 @@ fw config set --local default-stack true
 
 Stack metadata is designed to be compatible with GitHub's stacked PRs as they roll out.
 
-## Stack-Aware Provenance (Planned)
+## Stack-Aware Provenance
 
-For feedback that references a file/line, the goal is to identify which PR in the stack last touched that file. That makes it clear where fixes should land, especially when stacks are deep.
+For feedback that references a file/line, Firewatch can identify which PR in the stack last touched that file. That makes it clear where fixes should land, especially when stacks are deep. This is available when Graphite stacks are detected.
 
 ## Configuration
 

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -1,4 +1,4 @@
-import { getRepoCachePath, readJsonl, writeJsonl } from "./cache";
+import { getRepoCachePath, readEntriesJsonl, writeJsonl } from "./cache";
 import type { FirewatchEntry, FileActivityAfter } from "./schema/entry";
 
 interface CommitActivity {
@@ -137,7 +137,7 @@ export async function checkRepo(
   options: CheckOptions = {}
 ): Promise<CheckResult> {
   const cachePath = getRepoCachePath(repo);
-  const entries = await readJsonl<FirewatchEntry>(cachePath);
+  const entries = await readEntriesJsonl(cachePath);
   if (entries.length === 0) {
     return { repo, comments_checked: 0, entries_updated: 0 };
   }

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -1,3 +1,7 @@
-export { getGraphiteStacks, graphitePlugin } from "./graphite";
+export {
+  getFileProvenanceIndex,
+  getGraphiteStacks,
+  graphitePlugin,
+} from "./graphite";
 export type { GraphiteStack } from "./graphite";
 export type { FirewatchPlugin } from "./types";

--- a/packages/core/src/schema/docs.ts
+++ b/packages/core/src/schema/docs.ts
@@ -32,6 +32,16 @@ export const ENTRY_SCHEMA_DOC = {
         latest_commit_at: { type: "string", format: "date-time", optional: true },
       },
     },
+    file_provenance: {
+      type: "object",
+      optional: true,
+      fields: {
+        origin_pr: { type: "number" },
+        origin_branch: { type: "string" },
+        origin_commit: { type: "string" },
+        stack_position: { type: "number" },
+      },
+    },
     graphite: {
       type: "object",
       optional: true,

--- a/packages/core/src/schema/entry.ts
+++ b/packages/core/src/schema/entry.ts
@@ -21,6 +21,15 @@ export const FileActivityAfterSchema = z.object({
 
 export type FileActivityAfter = z.infer<typeof FileActivityAfterSchema>;
 
+export const FileProvenanceSchema = z.object({
+  origin_pr: z.number().int().positive(),
+  origin_branch: z.string(),
+  origin_commit: z.string(),
+  stack_position: z.number().int().positive(),
+});
+
+export type FileProvenance = z.infer<typeof FileProvenanceSchema>;
+
 /**
  * PR state enum.
  */
@@ -75,6 +84,7 @@ export const FirewatchEntrySchema = z.object({
   file: z.string().optional(),
   line: z.number().int().positive().optional(),
   file_activity_after: FileActivityAfterSchema.optional(),
+  file_provenance: FileProvenanceSchema.optional(),
 
   // Plugin data
   graphite: GraphiteMetadataSchema.optional(),

--- a/packages/core/tests/check.test.ts
+++ b/packages/core/tests/check.test.ts
@@ -98,3 +98,139 @@ test("checkRepo updates file_activity_after for comments", async () => {
   expect(secondComment?.file_activity_after?.modified).toBe(false);
   expect(secondComment?.file_activity_after?.commits_touching_file).toBe(0);
 });
+
+test("checkRepo uses file matches when commit files are available", async () => {
+  const repo = "outfitter-dev/firewatch";
+  const entries: FirewatchEntry[] = [
+    {
+      id: "comment-1",
+      repo,
+      pr: 99,
+      pr_title: "Add provenance",
+      pr_state: "open",
+      pr_author: "alice",
+      pr_branch: "feat/provenance",
+      type: "comment",
+      subtype: "review_comment",
+      author: "bob",
+      body: "Touch file",
+      file: "src/target.ts",
+      created_at: "2025-01-01T00:00:00.000Z",
+      captured_at: "2025-01-02T00:00:00.000Z",
+    },
+    {
+      id: "commit-1",
+      repo,
+      pr: 99,
+      pr_title: "Add provenance",
+      pr_state: "open",
+      pr_author: "alice",
+      pr_branch: "feat/provenance",
+      type: "commit",
+      author: "alice",
+      body: "Other file",
+      created_at: "2025-01-02T12:00:00.000Z",
+      captured_at: "2025-01-02T12:01:00.000Z",
+    },
+    {
+      id: "commit-2",
+      repo,
+      pr: 99,
+      pr_title: "Add provenance",
+      pr_state: "open",
+      pr_author: "alice",
+      pr_branch: "feat/provenance",
+      type: "commit",
+      author: "alice",
+      body: "Target file",
+      created_at: "2025-01-03T12:00:00.000Z",
+      captured_at: "2025-01-03T12:01:00.000Z",
+    },
+  ];
+
+  await writeJsonl(getRepoCachePath(repo), entries);
+
+  const filesByCommit = new Map<string, string[]>([
+    ["commit-1", ["src/other.ts"]],
+    ["commit-2", ["src/target.ts"]],
+  ]);
+  const result = await checkRepo(repo, {
+    resolveCommitFiles: (commitId: string) =>
+      Promise.resolve(filesByCommit.get(commitId) as string[]),
+  });
+
+  expect(result.comments_checked).toBe(1);
+
+  const updated = await readJsonl<FirewatchEntry>(getRepoCachePath(repo));
+  const comment = updated.find((entry) => entry.id === "comment-1");
+  expect(comment?.file_activity_after?.modified).toBe(true);
+  expect(comment?.file_activity_after?.commits_touching_file).toBe(1);
+  expect(comment?.file_activity_after?.latest_commit).toBe("commit-2");
+});
+
+test("checkRepo falls back to all commits when file lists are partial", async () => {
+  const repo = "outfitter-dev/firewatch";
+  const entries: FirewatchEntry[] = [
+    {
+      id: "comment-1",
+      repo,
+      pr: 101,
+      pr_title: "Add provenance",
+      pr_state: "open",
+      pr_author: "alice",
+      pr_branch: "feat/provenance",
+      type: "comment",
+      subtype: "review_comment",
+      author: "bob",
+      body: "Touch file",
+      file: "src/target.ts",
+      created_at: "2025-01-01T00:00:00.000Z",
+      captured_at: "2025-01-02T00:00:00.000Z",
+    },
+    {
+      id: "commit-1",
+      repo,
+      pr: 101,
+      pr_title: "Add provenance",
+      pr_state: "open",
+      pr_author: "alice",
+      pr_branch: "feat/provenance",
+      type: "commit",
+      author: "alice",
+      body: "Other file",
+      created_at: "2025-01-02T12:00:00.000Z",
+      captured_at: "2025-01-02T12:01:00.000Z",
+    },
+    {
+      id: "commit-2",
+      repo,
+      pr: 101,
+      pr_title: "Add provenance",
+      pr_state: "open",
+      pr_author: "alice",
+      pr_branch: "feat/provenance",
+      type: "commit",
+      author: "alice",
+      body: "Unknown files",
+      created_at: "2025-01-03T12:00:00.000Z",
+      captured_at: "2025-01-03T12:01:00.000Z",
+    },
+  ];
+
+  await writeJsonl(getRepoCachePath(repo), entries);
+
+  const filesByCommit = new Map<string, string[] | null>([
+    ["commit-1", ["src/other.ts"]],
+    ["commit-2", null],
+  ]);
+  await checkRepo(repo, {
+    resolveCommitFiles: (commitId: string) =>
+      Promise.resolve(filesByCommit.get(commitId) ?? null),
+  });
+
+  const updated = await readJsonl<FirewatchEntry>(getRepoCachePath(repo));
+  const comment = updated.find((entry) => entry.id === "comment-1");
+  expect(comment?.file_activity_after?.modified).toBe(true);
+  expect(comment?.file_activity_after?.commits_touching_file).toBe(1);
+  expect(comment?.file_activity_after?.latest_commit).toBe("commit-2");
+});


### PR DESCRIPTION
## Summary
- Add Graphite file provenance to map file-related feedback to the owning PR in a stack.
- Use local git (when available) to resolve commit file lists for more accurate staleness checks.
- Expose provenance fields in schema/docs for jq-friendly queries.

## Testing
- bun run test
- bun run check
