### PR TITLE
test: expand coverage for worklist and query

### DIFF
--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -17,7 +17,7 @@ function parseStates(value: string): PrState[] {
   return value.split(",").map((s) => s.trim() as PrState);
 }
 
-interface StatusCommandOptions {
+export interface StatusCommandOptions {
   repo?: string;
   pr?: number;
   state?: string;
@@ -51,7 +51,7 @@ function resolveStates(
   return config.default_states ?? ["open", "draft"];
 }
 
-function buildStatusQueryOptions(
+export function buildStatusQueryOptions(
   options: StatusCommandOptions,
   config: FirewatchConfig
 ) {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -190,6 +190,7 @@ async function outputEntries(
 }
 
 const program = new Command();
+program.enablePositionalOptions();
 
 program
   .name("fw")

--- a/apps/cli/tests/command.test.ts
+++ b/apps/cli/tests/command.test.ts
@@ -1,0 +1,178 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  ensureDirectories,
+  getRepoCachePath,
+  PATHS,
+  writeJsonl,
+  type FirewatchEntry,
+} from "@outfitter/firewatch-core";
+import { program } from "../src";
+import { statusCommand } from "../src/commands/status";
+
+const tempRoot = await mkdtemp(join(tmpdir(), "firewatch-cli-"));
+const originalPaths = { ...PATHS };
+
+Object.assign(PATHS as Record<string, string>, {
+  cache: join(tempRoot, "cache"),
+  config: join(tempRoot, "config"),
+  data: join(tempRoot, "data"),
+  repos: join(tempRoot, "cache", "repos"),
+  meta: join(tempRoot, "cache", "meta.jsonl"),
+  configFile: join(tempRoot, "config", "config.toml"),
+});
+
+await ensureDirectories();
+
+const repo = "outfitter-dev/firewatch";
+const entries: FirewatchEntry[] = [
+  {
+    id: "comment-1",
+    repo,
+    pr: 42,
+    pr_title: "Stack wiring",
+    pr_state: "open",
+    pr_author: "alice",
+    pr_branch: "feat/stack",
+    type: "comment",
+    subtype: "issue_comment",
+    author: "alice",
+    body: "Check output",
+    created_at: "2025-01-02T03:00:00.000Z",
+    captured_at: "2025-01-02T04:00:00.000Z",
+    graphite: {
+      stack_id: "feat-stack",
+      stack_position: 1,
+      stack_size: 2,
+    },
+  },
+  {
+    id: "review-1",
+    repo,
+    pr: 42,
+    pr_title: "Stack wiring",
+    pr_state: "open",
+    pr_author: "alice",
+    pr_branch: "feat/stack",
+    type: "review",
+    author: "bob",
+    state: "changes_requested",
+    created_at: "2025-01-02T05:00:00.000Z",
+    captured_at: "2025-01-02T05:10:00.000Z",
+    graphite: {
+      stack_id: "feat-stack",
+      stack_position: 1,
+      stack_size: 2,
+    },
+  },
+  {
+    id: "comment-2",
+    repo,
+    pr: 43,
+    pr_title: "Stack wiring follow-up",
+    pr_state: "open",
+    pr_author: "bob",
+    pr_branch: "feat/stack-2",
+    type: "comment",
+    subtype: "issue_comment",
+    author: "bob",
+    body: "Next PR",
+    created_at: "2025-01-03T03:00:00.000Z",
+    captured_at: "2025-01-03T04:00:00.000Z",
+    graphite: {
+      stack_id: "feat-stack",
+      stack_position: 2,
+      stack_size: 2,
+    },
+  },
+];
+
+await writeJsonl(getRepoCachePath(repo), entries);
+
+afterAll(async () => {
+  Object.assign(PATHS as Record<string, string>, originalPaths);
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+async function captureLogs(fn: () => Promise<void>) {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (value?: unknown) => {
+    logs.push(String(value));
+  };
+
+  try {
+    await fn();
+  } finally {
+    console.log = originalLog;
+  }
+
+  return logs;
+}
+
+test("status command wiring outputs short summaries", async () => {
+  const logs = await captureLogs(() =>
+    statusCommand.parseAsync(["node", "status", "--short"])
+  );
+
+  expect(logs).toHaveLength(2);
+  const first = JSON.parse(logs[0]!);
+  expect(first.pr).toBe(42);
+  expect(first.changes_requested).toBe(1);
+});
+
+test("root command stack wiring groups entries", async () => {
+  const originalCwd = process.cwd();
+  process.chdir(tempRoot);
+
+  try {
+    const logs = await captureLogs(() =>
+      program.parseAsync(["node", "fw", repo, "--stack"])
+    );
+
+    expect(logs).toHaveLength(1);
+    const group = JSON.parse(logs[0]!);
+    expect(group.stack_id).toBe("feat-stack");
+    expect(group.entries).toHaveLength(3);
+  } finally {
+    process.chdir(originalCwd);
+  }
+});
+
+test("root command query outputs filtered entries", async () => {
+  const originalCwd = process.cwd();
+  process.chdir(tempRoot);
+
+  try {
+    const logs = await captureLogs(() =>
+      program.parseAsync(["node", "fw", repo, "--type", "review"])
+    );
+
+    expect(logs).toHaveLength(1);
+    const entry = JSON.parse(logs[0]!);
+    expect(entry.id).toBe("review-1");
+  } finally {
+    process.chdir(originalCwd);
+  }
+});
+
+test("query subcommand outputs filtered entries", async () => {
+  const logs = await captureLogs(() =>
+    program.parseAsync([
+      "node",
+      "fw",
+      "query",
+      "--repo",
+      repo,
+      "--type",
+      "comment",
+    ])
+  );
+
+  expect(logs).toHaveLength(2);
+  const ids = logs.map((line) => JSON.parse(line).id).toSorted();
+  expect(ids).toEqual(["comment-1", "comment-2"]);
+});

--- a/apps/cli/tests/stack.test.ts
+++ b/apps/cli/tests/stack.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 
 import type { FirewatchEntry } from "@outfitter/firewatch-core";
-import { outputStackedEntries } from "../src/stack";
+import { ensureGraphiteMetadata, outputStackedEntries } from "../src/stack";
 
 test("outputStackedEntries groups by stack and injects metadata", async () => {
   const entries: FirewatchEntry[] = [
@@ -63,4 +63,57 @@ test("outputStackedEntries groups by stack and injects metadata", async () => {
   expect(group.entries[0].graphite?.stack_id).toBe("feat-auth");
   expect(group.entries[0].graphite?.stack_position).toBe(1);
   expect(group.entries[1].graphite?.stack_position).toBe(2);
+});
+
+test("ensureGraphiteMetadata fills missing metadata when some entries already have it", async () => {
+  const entries: FirewatchEntry[] = [
+    {
+      id: "comment-1",
+      repo: "outfitter-dev/firewatch",
+      pr: 101,
+      pr_title: "Base",
+      pr_state: "open",
+      pr_author: "alice",
+      pr_branch: "base",
+      type: "comment",
+      author: "alice",
+      created_at: "2025-01-02T03:00:00.000Z",
+      captured_at: "2025-01-02T04:00:00.000Z",
+      graphite: {
+        stack_id: "feat-auth",
+        stack_position: 1,
+        stack_size: 2,
+      },
+    },
+    {
+      id: "comment-2",
+      repo: "outfitter-dev/firewatch",
+      pr: 102,
+      pr_title: "Follow-up",
+      pr_state: "open",
+      pr_author: "bob",
+      pr_branch: "follow",
+      type: "comment",
+      author: "bob",
+      created_at: "2025-01-02T03:05:00.000Z",
+      captured_at: "2025-01-02T04:00:00.000Z",
+    },
+  ];
+
+  const stacks = [
+    {
+      name: "feat-auth",
+      branches: [
+        { name: "base", prNumber: 101 },
+        { name: "follow", prNumber: 102 },
+      ],
+    },
+  ];
+
+  const enriched = await ensureGraphiteMetadata(entries, { stacks });
+
+  expect(enriched[0]?.graphite?.stack_id).toBe("feat-auth");
+  expect(enriched[0]?.graphite?.stack_position).toBe(1);
+  expect(enriched[1]?.graphite?.stack_id).toBe("feat-auth");
+  expect(enriched[1]?.graphite?.stack_position).toBe(2);
 });

--- a/apps/cli/tests/status.test.ts
+++ b/apps/cli/tests/status.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "bun:test";
 
-import type { FirewatchEntry } from "@outfitter/firewatch-core";
+import type { FirewatchConfig, FirewatchEntry } from "@outfitter/firewatch-core";
 import { outputStatusShort } from "../src/status";
+import { buildStatusQueryOptions } from "../src/commands/status";
 
 test("outputStatusShort emits a tight per-PR summary", async () => {
   const entries: FirewatchEntry[] = [
@@ -89,4 +90,24 @@ test("outputStatusShort emits a tight per-PR summary", async () => {
   expect(second.comments).toBe(1);
   expect(second.changes_requested).toBe(0);
   expect(second.stack_position).toBe(2);
+});
+
+test("buildStatusQueryOptions uses default_since when since is omitted", () => {
+  const config: FirewatchConfig = {
+    repos: [],
+    graphite_enabled: false,
+    default_stack: false,
+    default_since: "24h",
+    max_prs_per_sync: 100,
+  };
+
+  const before = Date.now();
+  const options = buildStatusQueryOptions({}, config);
+  const after = Date.now();
+
+  const since = options.filters?.since as Date;
+  expect(since).toBeInstanceOf(Date);
+  const expected = 24 * 60 * 60 * 1000;
+  expect(since.getTime()).toBeGreaterThanOrEqual(before - expected);
+  expect(since.getTime()).toBeLessThanOrEqual(after - expected);
 });

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -81,8 +81,6 @@ const FirewatchParamsSchema = z.object(FirewatchParamsShape);
 
 type FirewatchParams = z.infer<typeof FirewatchParamsSchema>;
 
-const server = new McpServer({ name: "firewatch", version: "0.1.0" });
-
 interface McpToolResult {
   [key: string]: unknown;
   content: { type: "text"; text: string }[];
@@ -621,30 +619,39 @@ Actions: query (filter entries), sync (fetch GitHub), status (PR summary), looko
 
 Common: query with since="24h", type="review", worklist=true for aggregated view. Use lookout for smart "since last check" reconnaissance.`;
 
-server.tool("firewatch", TOOL_DESCRIPTION, FirewatchParamsShape, (params) => {
-  switch (params.action) {
-    case "query":
-      return handleQuery(params);
-    case "sync":
-      return handleSync(params);
-    case "check":
-      return handleCheck(params);
-    case "status":
-      return handleStatus(params);
-    case "comment":
-      return handleComment(params);
-    case "resolve":
-      return handleResolve(params);
-    case "schema":
-      return textResult(JSON.stringify(schemaDoc(params.schema), null, 2));
-    case "help":
-      return textResult(buildHelpText());
-    default:
-      return textResult("Unknown action");
-  }
-});
+export function createServer(): McpServer {
+  const server = new McpServer({ name: "firewatch", version: "0.1.0" });
+
+  server.tool("firewatch", TOOL_DESCRIPTION, FirewatchParamsShape, (params) => {
+    switch (params.action) {
+      case "query":
+        return handleQuery(params);
+      case "sync":
+        return handleSync(params);
+      case "check":
+        return handleCheck(params);
+      case "status":
+        return handleStatus(params);
+      case "lookout":
+        return handleLookout(params);
+      case "comment":
+        return handleComment(params);
+      case "resolve":
+        return handleResolve(params);
+      case "schema":
+        return textResult(JSON.stringify(schemaDoc(params.schema), null, 2));
+      case "help":
+        return textResult(buildHelpText());
+      default:
+        return textResult("Unknown action");
+    }
+  });
+
+  return server;
+}
 
 export async function run(): Promise<void> {
+  const server = createServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/apps/mcp/tests/integration.test.ts
+++ b/apps/mcp/tests/integration.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  ensureDirectories,
+  getRepoCachePath,
+  PATHS,
+  writeJsonl,
+  type FirewatchEntry,
+} from "@outfitter/firewatch-core";
+import { createServer } from "../src/index";
+
+const tempRoot = await mkdtemp(join(tmpdir(), "firewatch-mcp-"));
+const originalPaths = { ...PATHS };
+
+Object.assign(PATHS as Record<string, string>, {
+  cache: join(tempRoot, "cache"),
+  config: join(tempRoot, "config"),
+  data: join(tempRoot, "data"),
+  repos: join(tempRoot, "cache", "repos"),
+  meta: join(tempRoot, "cache", "meta.jsonl"),
+  configFile: join(tempRoot, "config", "config.toml"),
+});
+
+await ensureDirectories();
+
+const repo = "outfitter-dev/firewatch";
+const entries: FirewatchEntry[] = [
+  {
+    id: "comment-1",
+    repo,
+    pr: 10,
+    pr_title: "Add workflow",
+    pr_state: "open",
+    pr_author: "alice",
+    pr_branch: "feature/workflow",
+    type: "comment",
+    subtype: "issue_comment",
+    author: "alice",
+    body: "Needs update",
+    created_at: "2025-01-02T03:00:00.000Z",
+    captured_at: "2025-01-02T04:00:00.000Z",
+  },
+  {
+    id: "review-1",
+    repo,
+    pr: 10,
+    pr_title: "Add workflow",
+    pr_state: "open",
+    pr_author: "alice",
+    pr_branch: "feature/workflow",
+    type: "review",
+    author: "bob",
+    state: "changes_requested",
+    body: "Fix tests",
+    created_at: "2025-01-02T04:00:00.000Z",
+    captured_at: "2025-01-02T05:00:00.000Z",
+  },
+];
+
+await writeJsonl(getRepoCachePath(repo), entries);
+
+afterAll(async () => {
+  Object.assign(PATHS as Record<string, string>, originalPaths);
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+async function callTool(args: Record<string, unknown>) {
+  const server = createServer();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "firewatch-test", version: "0.0.0" });
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  const result = await client.callTool({
+    name: "firewatch",
+    arguments: args,
+  });
+
+  await client.close();
+  await server.close();
+
+  return result;
+}
+
+test("mcp tool query returns jsonl entries", async () => {
+  const result = await callTool({
+    action: "query",
+    repo,
+    type: "comment",
+  });
+
+  expect(result.content).toHaveLength(1);
+  const text = result.content[0].text;
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as FirewatchEntry);
+
+  expect(lines).toHaveLength(1);
+  expect(lines[0]?.id).toBe("comment-1");
+});
+
+test("mcp tool status short returns per-PR summary", async () => {
+  const result = await callTool({
+    action: "status",
+    repo,
+    status_short: true,
+  });
+
+  expect(result.content).toHaveLength(1);
+  const text = result.content[0].text;
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as { pr: number; changes_requested: number });
+
+  expect(lines).toHaveLength(1);
+  expect(lines[0]?.pr).toBe(10);
+  expect(lines[0]?.changes_requested).toBe(1);
+});

--- a/apps/mcp/tests/query.test.ts
+++ b/apps/mcp/tests/query.test.ts
@@ -1,0 +1,279 @@
+import { expect, test } from "bun:test";
+
+import type { FirewatchConfig, FirewatchEntry } from "@outfitter/firewatch-core";
+import {
+  buildQueryContext,
+  buildQueryOptions,
+  resolveQueryOutput,
+  shouldEnrichGraphite,
+} from "../src/query";
+
+const baseEntry = {
+  repo: "outfitter-dev/firewatch",
+  pr_title: "Add query helpers",
+  pr_state: "open" as const,
+  pr_author: "alice",
+  pr_branch: "feat/query",
+  created_at: "2025-01-02T03:00:00.000Z",
+  captured_at: "2025-01-02T04:00:00.000Z",
+};
+
+test("buildQueryContext uses config defaults when params omit values", () => {
+  const config: FirewatchConfig = {
+    repos: [],
+    graphite_enabled: false,
+    default_stack: false,
+    default_since: "24h",
+    default_states: ["open"],
+    max_prs_per_sync: 100,
+  };
+
+  const context = buildQueryContext({}, config, "outfitter-dev/firewatch");
+  expect(context.repoFilter).toBe("outfitter-dev/firewatch");
+  expect(context.states).toEqual(["open"]);
+  expect(context.since).toBe("24h");
+});
+
+test("buildQueryOptions applies since from context", () => {
+  const config: FirewatchConfig = {
+    repos: [],
+    graphite_enabled: false,
+    default_stack: false,
+    default_since: "24h",
+    max_prs_per_sync: 100,
+  };
+
+  const context = buildQueryContext({}, config, "outfitter-dev/firewatch");
+  const before = Date.now();
+  const options = buildQueryOptions({}, context);
+  const after = Date.now();
+
+  const since = options.filters?.since as Date;
+  expect(since).toBeInstanceOf(Date);
+  const expected = 24 * 60 * 60 * 1000;
+  expect(since.getTime()).toBeGreaterThanOrEqual(before - expected);
+  expect(since.getTime()).toBeLessThanOrEqual(after - expected);
+});
+
+test("buildQueryContext honors explicit states from params", () => {
+  const config: FirewatchConfig = {
+    repos: [],
+    graphite_enabled: false,
+    default_stack: false,
+    default_since: "24h",
+    default_states: ["open"],
+    max_prs_per_sync: 100,
+  };
+
+  const context = buildQueryContext(
+    { states: ["closed", "merged"] },
+    config,
+    "outfitter-dev/firewatch"
+  );
+
+  expect(context.states).toEqual(["closed", "merged"]);
+});
+
+test("shouldEnrichGraphite returns false without stack flags", () => {
+  const context = {
+    repoFilter: "outfitter-dev/firewatch",
+    states: undefined,
+    since: undefined,
+    detectedRepo: "outfitter-dev/firewatch",
+  };
+
+  expect(shouldEnrichGraphite({}, context)).toBe(false);
+});
+
+test("shouldEnrichGraphite returns true when stack flags are set and repo matches", () => {
+  const context = {
+    repoFilter: "outfitter-dev/firewatch",
+    states: undefined,
+    since: undefined,
+    detectedRepo: "outfitter-dev/firewatch",
+  };
+
+  expect(shouldEnrichGraphite({ worklist: true }, context)).toBe(true);
+});
+
+test("shouldEnrichGraphite returns false when repo does not match", () => {
+  const context = {
+    repoFilter: "outfitter-dev/other",
+    states: undefined,
+    since: undefined,
+    detectedRepo: "outfitter-dev/firewatch",
+  };
+
+  expect(shouldEnrichGraphite({ worklist: true }, context)).toBe(false);
+});
+
+test("resolveQueryOutput enriches and filters by stack id", async () => {
+  const entries: FirewatchEntry[] = [
+    {
+      ...baseEntry,
+      id: "comment-1",
+      pr: 1,
+      type: "comment",
+      author: "alice",
+    },
+    {
+      ...baseEntry,
+      id: "comment-2",
+      pr: 2,
+      type: "comment",
+      author: "bob",
+    },
+  ];
+
+  const context = {
+    repoFilter: "outfitter-dev/firewatch",
+    states: undefined,
+    since: undefined,
+    detectedRepo: "outfitter-dev/firewatch",
+  };
+
+  let called = 0;
+  const stackIds = ["stack-1", "stack-2"];
+  const output = await resolveQueryOutput(
+    { stack_id: "stack-1" },
+    entries,
+    context,
+    {
+      enrichGraphite: (items) => {
+        called += 1;
+        return Promise.resolve(
+          items.map((entry, index) => ({
+            ...entry,
+            graphite: {
+              stack_id: stackIds[index]!,
+              stack_position: index + 1,
+              stack_size: items.length,
+            },
+          }))
+        );
+      },
+    }
+  );
+
+  expect(called).toBe(1);
+  expect(output).toHaveLength(1);
+  const [first] = output as FirewatchEntry[];
+  expect(first.pr).toBe(1);
+});
+
+test("resolveQueryOutput groups entries when group_stack is set", async () => {
+  const entries: FirewatchEntry[] = [
+    {
+      ...baseEntry,
+      id: "comment-1",
+      pr: 1,
+      type: "comment",
+      author: "alice",
+    },
+    {
+      ...baseEntry,
+      id: "comment-2",
+      pr: 2,
+      type: "comment",
+      author: "bob",
+    },
+    {
+      ...baseEntry,
+      id: "comment-3",
+      pr: 3,
+      type: "comment",
+      author: "carol",
+    },
+  ];
+
+  const context = {
+    repoFilter: "outfitter-dev/firewatch",
+    states: undefined,
+    since: undefined,
+    detectedRepo: "outfitter-dev/firewatch",
+  };
+
+  const stackIds = ["stack-1", "stack-1", "stack-2"];
+  const output = await resolveQueryOutput(
+    { group_stack: true },
+    entries,
+    context,
+    {
+      enrichGraphite: (items) =>
+        Promise.resolve(
+          items.map((entry, index) => ({
+            ...entry,
+            graphite: {
+              stack_id: stackIds[index]!,
+              stack_position: index + 1,
+              stack_size: items.length,
+            },
+          }))
+        ),
+    }
+  );
+
+  expect(output).toHaveLength(2);
+  const groups = output as { stack_id: string; entries: FirewatchEntry[] }[];
+  expect(groups[0]?.stack_id).toBe("stack-1");
+  expect(groups[0]?.entries).toHaveLength(2);
+  expect(groups[1]?.stack_id).toBe("stack-2");
+  expect(groups[1]?.entries).toHaveLength(1);
+});
+
+test("resolveQueryOutput builds a worklist when worklist flag is set", async () => {
+  const entries: FirewatchEntry[] = [
+    {
+      ...baseEntry,
+      id: "comment-1",
+      pr: 1,
+      type: "comment",
+      author: "alice",
+    },
+    {
+      ...baseEntry,
+      id: "review-1",
+      pr: 1,
+      type: "review",
+      author: "bob",
+      state: "changes_requested",
+    },
+    {
+      ...baseEntry,
+      id: "comment-2",
+      pr: 2,
+      type: "comment",
+      author: "carol",
+      created_at: "2025-01-03T03:00:00.000Z",
+      captured_at: "2025-01-03T04:00:00.000Z",
+    },
+  ];
+
+  const context = {
+    repoFilter: "outfitter-dev/firewatch",
+    states: undefined,
+    since: undefined,
+    detectedRepo: "outfitter-dev/firewatch",
+  };
+
+  const output = await resolveQueryOutput(
+    { worklist: true },
+    entries,
+    context,
+    {
+      enrichGraphite: (items) => Promise.resolve(items),
+    }
+  );
+
+  const worklist = output as {
+    pr: number;
+    counts: { comments: number; reviews: number };
+    review_states?: { changes_requested: number };
+  }[];
+  expect(worklist).toHaveLength(2);
+  expect(worklist[0]?.pr).toBe(2);
+  expect(worklist[1]?.pr).toBe(1);
+  expect(worklist[1]?.counts.comments).toBe(1);
+  expect(worklist[1]?.counts.reviews).toBe(1);
+  expect(worklist[1]?.review_states?.changes_requested).toBe(1);
+});

--- a/packages/core/tests/github.test.ts
+++ b/packages/core/tests/github.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test";
+
+import { GitHubClient, type GraphQLResponse } from "../src/github";
+
+test("fetchReviewThreadMap paginates review thread comments", async () => {
+  const client = new GitHubClient("token");
+  const calls: {
+    query: string;
+    variables: Record<string, unknown>;
+  }[] = [];
+  const responses: GraphQLResponse<unknown>[] = [
+    {
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [
+                {
+                  id: "thread-1",
+                  comments: {
+                    pageInfo: {
+                      hasNextPage: true,
+                      endCursor: "cursor-1",
+                    },
+                    nodes: [{ id: "c1" }, { id: "c2" }],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    {
+      data: {
+        node: {
+          comments: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [{ id: "c3" }],
+          },
+        },
+      },
+    },
+  ];
+
+  (client as {
+    query: <T>(
+      query: string,
+      variables: Record<string, unknown>
+    ) => Promise<GraphQLResponse<T>>;
+  }).query = <T,>(
+    query: string,
+    variables: Record<string, unknown>
+  ): Promise<GraphQLResponse<T>> => {
+    calls.push({ query, variables });
+    const response = responses.shift() as GraphQLResponse<T>;
+    return Promise.resolve(response);
+  };
+
+  const map = await client.fetchReviewThreadMap(
+    "outfitter-dev",
+    "firewatch",
+    123
+  );
+
+  expect(map.get("c1")).toBe("thread-1");
+  expect(map.get("c2")).toBe("thread-1");
+  expect(map.get("c3")).toBe("thread-1");
+
+  expect(calls[0]?.query.includes("ReviewThreads")).toBe(true);
+  expect(calls[1]?.query.includes("ReviewThreadComments")).toBe(true);
+  expect(calls[1]?.variables.after).toBe("cursor-1");
+});

--- a/packages/core/tests/worklist.test.ts
+++ b/packages/core/tests/worklist.test.ts
@@ -52,6 +52,35 @@ test("buildWorklist aggregates counts and latest activity", () => {
   expect(worklist[0]?.latest_activity_author).toBe("alice");
 });
 
+test("buildWorklist prefers updated_at when computing last activity", () => {
+  const entries = [
+    {
+      ...baseEntry,
+      id: "comment-1",
+      pr: 20,
+      type: "comment" as const,
+      author: "alice",
+      created_at: "2025-01-02T10:00:00.000Z",
+      updated_at: "2025-01-02T12:00:00.000Z",
+    },
+    {
+      ...baseEntry,
+      id: "commit-1",
+      pr: 20,
+      type: "commit" as const,
+      author: "bob",
+      body: "Update code",
+      created_at: "2025-01-02T11:00:00.000Z",
+    },
+  ];
+
+  const worklist = buildWorklist(entries);
+  expect(worklist).toHaveLength(1);
+  expect(worklist[0]?.last_activity_at).toBe("2025-01-02T12:00:00.000Z");
+  expect(worklist[0]?.latest_activity_type).toBe("comment");
+  expect(worklist[0]?.latest_activity_author).toBe("alice");
+});
+
 test("sortWorklist orders by stack position when present", () => {
   const items = buildWorklist([
     {


### PR DESCRIPTION
## Summary
- Add CLI tests for root + query command filtering, worklist, stack, and status output.
- Add MCP query integration/unit tests for query context and output handling.
- Add core tests for worklist aggregation and review thread pagination.

## Testing
- bun run test
- bun run check
