### PR TITLE
fix: address sync and docs feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# AGENTS.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ fw sync
 fw sync owner/repo
 fw sync --since 7d
 fw sync --full
+fw sync --stack
 ```
+
+`--stack` is an alias for `--with-graphite` when you want stack metadata during sync.
 
 ### check
 
@@ -76,6 +79,8 @@ fw query --limit 50
 fw query --stack
 fw query --worklist
 ```
+
+Most commands emit JSONL by default; `--json` is accepted everywhere as an explicit alias.
 
 ### config
 
@@ -130,10 +135,10 @@ fw resolve comment-2001 comment-2002
 
 ## Configuration
 
-Firewatch loads configuration in this order (project overrides user):
+Firewatch loads configuration in this order (later sources override earlier):
 
-1. Project config: `.firewatch.toml` (repo root)
-2. User config: `~/.config/firewatch/config.toml`
+1. User config: `~/.config/firewatch/config.toml`
+2. Project config: `.firewatch.toml` (repo root)
 
 Example:
 
@@ -160,10 +165,10 @@ Stack metadata is designed to be compatible with GitHub's stacked PRs as they ro
 
 XDG-compliant cache and config locations:
 
-```
+```text
 ~/.cache/firewatch/
 ├── repos/
-│   └── owner--repo.jsonl
+│   └── b64~<encoded>.jsonl
 └── meta.jsonl
 
 ~/.config/firewatch/

--- a/apps/cli/src/commands/mcp.ts
+++ b/apps/cli/src/commands/mcp.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 
 export const mcpCommand = new Command("mcp")
   .description("Start the MCP server for AI assistant integration")
+  .option("--json", "Output JSON (default)")
   .action(async () => {
     await run();
   });

--- a/apps/cli/src/commands/recap.ts
+++ b/apps/cli/src/commands/recap.ts
@@ -1,8 +1,11 @@
 import {
-  type PrState,
   buildWorklist,
+  detectRepo,
+  loadConfig,
+  parseSince,
   queryEntries,
   sortWorklist,
+  type WorklistEntry,
 } from "@outfitter/firewatch-core";
 import {
   getGraphiteStacks,
@@ -10,28 +13,128 @@ import {
 } from "@outfitter/firewatch-core/plugins";
 import { Command } from "commander";
 
+import { resolveStates } from "../utils/states";
+import { writeJsonLine } from "../utils/json";
+
 interface RecapCommandOptions {
   repo?: string;
+  all?: boolean;
+  state?: string;
+  open?: boolean;
+  draft?: boolean;
+  active?: boolean;
   since?: string;
+  json?: boolean;
+}
+
+interface RecapSummary {
+  total: number;
+  totalComments: number;
+  needsResponse: WorklistEntry[];
+  ready: WorklistEntry[];
+  drafts: WorklistEntry[];
+}
+
+function buildRecapSummary(worklist: WorklistEntry[]): RecapSummary {
+  const needsResponse = worklist.filter(
+    (w) => (w.review_states?.changes_requested ?? 0) > 0
+  );
+  const ready = worklist.filter(
+    (w) =>
+      w.pr_state === "open" &&
+      (w.review_states?.approved ?? 0) > 0 &&
+      (w.review_states?.changes_requested ?? 0) === 0
+  );
+  const drafts = worklist.filter((w) => w.pr_state === "draft");
+  const totalComments = worklist.reduce(
+    (sum, w) => sum + w.counts.comments,
+    0
+  );
+
+  return {
+    total: worklist.length,
+    totalComments,
+    needsResponse,
+    ready,
+    drafts,
+  };
+}
+
+function formatRecapGroup(
+  label: string,
+  items: WorklistEntry[]
+): string | null {
+  if (items.length === 0) {
+    return null;
+  }
+  const prs = items.slice(0, 5).map((w) => `#${w.pr}`).join(", ");
+  const more = items.length > 5 ? ` +${items.length - 5}` : "";
+  return `- ${label} (${items.length}): ${prs}${more}`;
+}
+
+function printRecapSummary(summary: RecapSummary): void {
+  console.log(
+    `Firewatch: ${summary.total} open PRs, ${summary.totalComments} comments`
+  );
+
+  const lines = [
+    formatRecapGroup("Changes Requested", summary.needsResponse),
+    formatRecapGroup("Ready to Merge", summary.ready),
+    formatRecapGroup("Drafts", summary.drafts),
+  ];
+
+  for (const line of lines) {
+    if (line) {
+      console.log(line);
+    }
+  }
+
+  console.log("\nRun `fw status --short` for JSONL output");
 }
 
 export const recapCommand = new Command("recap")
   .description("Human-readable summary of PR activity")
-  .option("--repo <name>", "Filter by repository")
+  .option("--repo <name>", "Filter by repository (partial match)")
+  .option("--all", "Query across all cached repos")
+  .option(
+    "--state <states>",
+    "Filter by PR state (comma-separated: open,closed,merged,draft)"
+  )
+  .option("--open", "Shorthand for --state open")
+  .option("--draft", "Shorthand for --state draft")
+  .option("--active", "Shorthand for --state open,draft")
   .option("--since <duration>", "Filter by time (e.g., 24h, 7d)")
+  .option("--json", "Output JSONL instead of text")
   .action(async (options: RecapCommandOptions) => {
     try {
-      const states: PrState[] = ["open", "draft"];
+      let repoFilter = options.repo;
+      if (!repoFilter && !options.all) {
+        const detected = await detectRepo();
+        if (detected.repo) {
+          console.error(`Querying ${detected.repo} (from ${detected.source})`);
+          repoFilter = detected.repo;
+        }
+      }
+
+      const config = await loadConfig();
+      const states = resolveStates(options, config);
+      const since = options.since ?? config.default_since;
 
       const entries = await queryEntries({
         filters: {
-          ...(options.repo && { repo: options.repo }),
+          ...(repoFilter && { repo: repoFilter }),
           states,
+          ...(since && { since: parseSince(since) }),
         },
       });
 
       if (entries.length === 0) {
-        console.log("No open PRs found. Run `fw sync` to fetch data.");
+        const message = "No open PRs found. Run `fw sync` to fetch data.";
+        if (options.json) {
+          console.error(message);
+          return;
+        }
+        console.log(message);
         return;
       }
 
@@ -46,46 +149,15 @@ export const recapCommand = new Command("recap")
 
       const worklist = sortWorklist(buildWorklist(enrichedEntries));
 
-      // Categorize PRs
-      const needsResponse = worklist.filter(
-        (w) => (w.review_states?.changes_requested ?? 0) > 0
-      );
-      const ready = worklist.filter(
-        (w) =>
-          w.pr_state === "open" &&
-          (w.review_states?.approved ?? 0) > 0 &&
-          (w.review_states?.changes_requested ?? 0) === 0
-      );
-      const drafts = worklist.filter((w) => w.pr_state === "draft");
-      const totalComments = worklist.reduce(
-        (sum, w) => sum + w.counts.comments,
-        0
-      );
-
-      // Header
-      console.log(`Firewatch: ${worklist.length} open PRs, ${totalComments} comments`);
-
-      // Categories as compact lines
-      if (needsResponse.length > 0) {
-        const prs = needsResponse.slice(0, 5).map((w) => `#${w.pr}`).join(", ");
-        const more = needsResponse.length > 5 ? ` +${needsResponse.length - 5}` : "";
-        console.log(`- Changes Requested (${needsResponse.length}): ${prs}${more}`);
+      if (options.json) {
+        for (const item of worklist) {
+          await writeJsonLine(item);
+        }
+        return;
       }
 
-      if (ready.length > 0) {
-        const prs = ready.slice(0, 5).map((w) => `#${w.pr}`).join(", ");
-        const more = ready.length > 5 ? ` +${ready.length - 5}` : "";
-        console.log(`- Ready to Merge (${ready.length}): ${prs}${more}`);
-      }
-
-      if (drafts.length > 0) {
-        const prs = drafts.slice(0, 5).map((w) => `#${w.pr}`).join(", ");
-        const more = drafts.length > 5 ? ` +${drafts.length - 5}` : "";
-        console.log(`- Drafts (${drafts.length}): ${prs}${more}`);
-      }
-
-      // Footer
-      console.log(`\nRun \`fw status --short\` for JSONL output`);
+      const summary = buildRecapSummary(worklist);
+      printRecapSummary(summary);
     } catch (error) {
       console.error(
         "Recap failed:",

--- a/apps/cli/src/commands/resolve.ts
+++ b/apps/cli/src/commands/resolve.ts
@@ -7,6 +7,7 @@ import {
 import { Command } from "commander";
 
 import { parseRepoInput } from "../repo";
+import { writeJsonLine } from "../utils/json";
 
 interface ResolveCommandOptions {
   repo?: string;
@@ -113,15 +114,13 @@ async function resolveTargets(
         resolvedThreads.add(threadId);
       }
 
-      console.log(
-        JSON.stringify({
-          ok: true,
-          repo,
-          pr,
-          comment_id: target.commentId,
-          thread_id: threadId,
-        })
-      );
+      await writeJsonLine({
+        ok: true,
+        repo,
+        pr,
+        comment_id: target.commentId,
+        thread_id: threadId,
+      });
     }
   }
 
@@ -133,6 +132,7 @@ export const resolveCommand = new Command("resolve")
   .argument("<commentIds...>", "Review comment IDs to resolve")
   .option("--repo <name>", "Repository (owner/repo format)")
   .option("--pr <number>", "PR number", Number.parseInt)
+  .option("--json", "Output JSON (default)")
   .action(async (commentIds: string[], options: ResolveCommandOptions) => {
     try {
       if (commentIds.length === 0) {

--- a/apps/cli/src/commands/schema.ts
+++ b/apps/cli/src/commands/schema.ts
@@ -20,6 +20,7 @@ export function printSchema(name: SchemaName): void {
 export const schemaCommand = new Command("schema")
   .description("Print schema information")
   .argument("[name]", "query | entry | worklist", "query")
+  .option("--json", "Output JSON (default)")
   .action((name: SchemaName) => {
     if (!schemaMap[name]) {
       console.error(`Unknown schema: ${name}`);

--- a/apps/cli/src/stack.ts
+++ b/apps/cli/src/stack.ts
@@ -7,6 +7,7 @@ import {
   type GraphiteStack,
 } from "@outfitter/firewatch-core/plugins";
 
+import { writeJsonLine } from "./utils/json";
 interface StackGroup {
   stack_id: string;
   entries: FirewatchEntry[];
@@ -111,7 +112,7 @@ export async function outputStackedEntries(
   }
 
   for (const group of groups) {
-    console.log(JSON.stringify(group));
+    await writeJsonLine(group);
   }
 
   return true;

--- a/apps/cli/src/status.ts
+++ b/apps/cli/src/status.ts
@@ -7,6 +7,7 @@ import {
 import type { GraphiteStack } from "@outfitter/firewatch-core/plugins";
 
 import { ensureGraphiteMetadata } from "./stack";
+import { writeJsonLine } from "./utils/json";
 
 export interface StatusShortEntry {
   repo: string;
@@ -62,7 +63,7 @@ export async function outputStatusShort(
   }
 
   for (const item of items) {
-    console.log(JSON.stringify(item));
+    await writeJsonLine(item);
   }
 
   return true;

--- a/apps/cli/src/utils/json.ts
+++ b/apps/cli/src/utils/json.ts
@@ -1,0 +1,9 @@
+import { once } from "node:events";
+
+export async function writeJsonLine(value: unknown): Promise<void> {
+  const serialized = JSON.stringify(value);
+  const line = `${serialized ?? "null"}\n`;
+  if (!process.stdout.write(line)) {
+    await once(process.stdout, "drain");
+  }
+}

--- a/apps/cli/src/utils/output.ts
+++ b/apps/cli/src/utils/output.ts
@@ -1,0 +1,59 @@
+import type {
+  FirewatchConfig,
+  FirewatchEntry,
+} from "@outfitter/firewatch-core";
+
+import { outputStackedEntries } from "../stack";
+import { outputWorklist } from "../worklist";
+import { writeJsonLine } from "./json";
+
+export interface OutputOptions {
+  stack?: boolean;
+  worklist?: boolean;
+  since?: string;
+  state?: string;
+  open?: boolean;
+  draft?: boolean;
+  active?: boolean;
+}
+
+export async function outputEntries(
+  entries: FirewatchEntry[],
+  options: OutputOptions,
+  config: FirewatchConfig
+): Promise<void> {
+  if (options.worklist) {
+    const wrote = await outputWorklist(entries);
+    if (!wrote) {
+      const hints: string[] = [];
+      if (!options.since && config.default_since) {
+        hints.push(`default_since=${config.default_since}`);
+      }
+      if (!options.state && !options.open && !options.draft && !options.active) {
+        const states = config.default_states;
+        if (states && states.length > 0) {
+          hints.push(`default_states=${states.join(",")}`);
+        }
+      }
+      const suffix = hints.length > 0 ? ` (filters: ${hints.join(", ")})` : "";
+      console.error(`No entries found for worklist.${suffix}`);
+      console.error("Try widening filters with --since or --state.");
+    }
+    return;
+  }
+
+  const stackMode = options.stack || config.default_stack;
+  if (stackMode) {
+    const wrote = await outputStackedEntries(entries);
+    if (!wrote) {
+      console.error(
+        "No Graphite stack data found. Run `fw sync --with-graphite` from the repo or enable graphite in config."
+      );
+    }
+    return;
+  }
+
+  for (const entry of entries) {
+    await writeJsonLine(entry);
+  }
+}

--- a/apps/cli/src/utils/states.ts
+++ b/apps/cli/src/utils/states.ts
@@ -1,0 +1,34 @@
+import type { FirewatchConfig, PrState } from "@outfitter/firewatch-core";
+
+export interface StateOptions {
+  state?: string;
+  open?: boolean;
+  draft?: boolean;
+  active?: boolean;
+}
+
+export function parseStates(value: string): PrState[] {
+  return value.split(",").map((s) => s.trim() as PrState);
+}
+
+export function resolveStates(
+  options: StateOptions,
+  config: FirewatchConfig
+): PrState[] {
+  if (options.state) {
+    return parseStates(options.state);
+  }
+  if (options.active) {
+    return ["open", "draft"];
+  }
+  if (options.open && options.draft) {
+    return ["open", "draft"];
+  }
+  if (options.open) {
+    return ["open"];
+  }
+  if (options.draft) {
+    return ["draft"];
+  }
+  return config.default_states ?? ["open", "draft"];
+}

--- a/apps/cli/src/worklist.ts
+++ b/apps/cli/src/worklist.ts
@@ -1,6 +1,7 @@
 import { buildWorklist, sortWorklist, type FirewatchEntry } from "@outfitter/firewatch-core";
 
 import { ensureGraphiteMetadata } from "./stack";
+import { writeJsonLine } from "./utils/json";
 
 export async function outputWorklist(
   entries: FirewatchEntry[]
@@ -13,7 +14,7 @@ export async function outputWorklist(
   }
 
   for (const item of worklist) {
-    console.log(JSON.stringify(item));
+    await writeJsonLine(item);
   }
 
   return true;

--- a/apps/cli/tests/command.test.ts
+++ b/apps/cli/tests/command.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@outfitter/firewatch-core";
 import { program } from "../src";
 import { statusCommand } from "../src/commands/status";
+import { captureStdout } from "./helpers";
 
 const tempRoot = await mkdtemp(join(tmpdir(), "firewatch-cli-"));
 const originalPaths = { ...PATHS };
@@ -97,24 +98,8 @@ afterAll(async () => {
   await rm(tempRoot, { recursive: true, force: true });
 });
 
-async function captureLogs(fn: () => Promise<void>) {
-  const logs: string[] = [];
-  const originalLog = console.log;
-  console.log = (value?: unknown) => {
-    logs.push(String(value));
-  };
-
-  try {
-    await fn();
-  } finally {
-    console.log = originalLog;
-  }
-
-  return logs;
-}
-
 test("status command wiring outputs short summaries", async () => {
-  const logs = await captureLogs(() =>
+  const logs = await captureStdout(() =>
     statusCommand.parseAsync(["node", "status", "--short"])
   );
 
@@ -129,7 +114,7 @@ test("root command stack wiring groups entries", async () => {
   process.chdir(tempRoot);
 
   try {
-    const logs = await captureLogs(() =>
+    const logs = await captureStdout(() =>
       program.parseAsync(["node", "fw", repo, "--stack"])
     );
 
@@ -147,7 +132,7 @@ test("root command query outputs filtered entries", async () => {
   process.chdir(tempRoot);
 
   try {
-    const logs = await captureLogs(() =>
+    const logs = await captureStdout(() =>
       program.parseAsync(["node", "fw", repo, "--type", "review"])
     );
 
@@ -160,7 +145,7 @@ test("root command query outputs filtered entries", async () => {
 });
 
 test("query subcommand outputs filtered entries", async () => {
-  const logs = await captureLogs(() =>
+  const logs = await captureStdout(() =>
     program.parseAsync([
       "node",
       "fw",

--- a/apps/cli/tests/helpers.ts
+++ b/apps/cli/tests/helpers.ts
@@ -1,0 +1,34 @@
+const formatChunk = (chunk: unknown): string => {
+  if (typeof chunk === "string") {
+    return chunk;
+  }
+  if (chunk instanceof Uint8Array) {
+    return Buffer.from(chunk).toString("utf8");
+  }
+  return String(chunk);
+};
+
+export async function captureStdout(
+  fn: () => Promise<void>
+): Promise<string[]> {
+  const chunks: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+
+  process.stdout.write = ((...args: unknown[]) => {
+    const text = formatChunk(args[0]);
+    chunks.push(text);
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+
+  return chunks
+    .join("")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}

--- a/apps/cli/tests/stack.test.ts
+++ b/apps/cli/tests/stack.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 
 import type { FirewatchEntry } from "@outfitter/firewatch-core";
 import { ensureGraphiteMetadata, outputStackedEntries } from "../src/stack";
+import { captureStdout } from "./helpers";
 
 test("outputStackedEntries groups by stack and injects metadata", async () => {
   const entries: FirewatchEntry[] = [
@@ -43,18 +44,10 @@ test("outputStackedEntries groups by stack and injects metadata", async () => {
     },
   ];
 
-  const logs: string[] = [];
-  const originalLog = console.log;
-  console.log = (value?: unknown) => {
-    logs.push(String(value));
-  };
-
-  try {
+  const logs = await captureStdout(async () => {
     const wrote = await outputStackedEntries(entries, { stacks });
     expect(wrote).toBe(true);
-  } finally {
-    console.log = originalLog;
-  }
+  });
 
   expect(logs).toHaveLength(1);
   const group = JSON.parse(logs[0]!);

--- a/apps/cli/tests/status.test.ts
+++ b/apps/cli/tests/status.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 import type { FirewatchConfig, FirewatchEntry } from "@outfitter/firewatch-core";
 import { outputStatusShort } from "../src/status";
 import { buildStatusQueryOptions } from "../src/commands/status";
+import { captureStdout } from "./helpers";
 
 test("outputStatusShort emits a tight per-PR summary", async () => {
   const entries: FirewatchEntry[] = [
@@ -63,18 +64,10 @@ test("outputStatusShort emits a tight per-PR summary", async () => {
     },
   ];
 
-  const logs: string[] = [];
-  const originalLog = console.log;
-  console.log = (value?: unknown) => {
-    logs.push(String(value));
-  };
-
-  try {
+  const logs = await captureStdout(async () => {
     const wrote = await outputStatusShort(entries);
     expect(wrote).toBe(true);
-  } finally {
-    console.log = originalLog;
-  }
+  });
 
   expect(logs).toHaveLength(2);
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -24,9 +24,13 @@ fw sync --since 7d
 
 # Full refresh (use occasionally)
 fw sync --full
+
+# Stack metadata (Graphite)
+fw sync --stack
 ```
 
 When running `fw` inside a repo with no cache yet, it auto-syncs first and then runs your query.
+Most commands emit JSONL by default; `--json` is accepted as an explicit alias.
 
 ## Check
 
@@ -115,10 +119,10 @@ For feedback that references a file/line, Firewatch can identify which PR in the
 
 ## Configuration
 
-Firewatch loads config in this order (project overrides user):
+Firewatch loads config in this order (later sources override earlier):
 
-1. `.firewatch.toml` (repo root)
-2. `~/.config/firewatch/config.toml`
+1. `~/.config/firewatch/config.toml`
+2. `.firewatch.toml` (repo root)
 
 Common defaults:
 

--- a/docs/development/graphite-integration.md
+++ b/docs/development/graphite-integration.md
@@ -12,26 +12,23 @@ Firewatch's Graphite plugin enriches PR activity entries with stack context. Thi
 
 | Command | Output | Useful For |
 |---------|--------|------------|
-| `gt log --stack` | Human-readable branch tree | Understanding stack structure |
+| `gt log --stack --no-interactive` | Human-readable branch tree | Understanding stack structure |
 | `gt branch info` | Branch details | Current branch context |
 | `gt branch info --stat` | Diffstat vs parent | File change summary (human-readable) |
 | `gt branch info --diff` | Full diff vs parent | Detailed changes (human-readable) |
-| `gt branch info --json` | JSON with `parent` field | Programmatic parent lookup |
 
 ### What gt Does NOT Expose
 
-- **File changes in JSON** — No `--json` flag for `--stat` or `--diff` output
-- **Stack-wide file mapping** — No command to get "which branch changed which files"
-- **PR numbers in JSON** — Must get from GitHub API or parse human-readable output
+- **JSON output** — Current gt versions do not expose JSON for stack structure.
+- **File changes in JSON** — No `--json` flag for `--stat` or `--diff` output.
+- **Stack-wide file mapping** — No command to get "which branch changed which files".
 
 ### JSON Output Availability
 
 ```bash
-# Works - gives parent branch
-gt branch info --json | jq -r '.parent'
-
-# Does NOT work - no JSON for file changes
-gt branch info --stat --json  # --json ignored, outputs human-readable
+# Not supported in current gt versions
+gt log --json      # unknown argument: json
+gt branch info --json
 ```
 
 ## Hybrid Approach: gt + git
@@ -139,11 +136,10 @@ async function buildFileProvenanceMap(): Promise<Map<string, FileProvenance>> {
 gt can detect this but requires local checkout:
 
 ```bash
-# Check if current branch needs restack
-gt branch restack --dry-run  # No actual --dry-run flag exists
-
-# Alternative: compare branch base with parent HEAD
-git merge-base ${branch} ${parent} != git rev-parse ${parent}
+# gt branch restack has no dry-run flag; use merge-base to detect drift
+if [ "$(git merge-base "${branch}" "${parent}")" != "$(git rev-parse "${parent}")" ]; then
+  echo "restack needed"
+fi
 ```
 
 ### Parent Merged

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import { readdir } from "node:fs/promises";
 
 import {
@@ -205,6 +206,7 @@ export async function queryEntries(
  */
 export function outputJsonl(entries: FirewatchEntry[]): void {
   for (const entry of entries) {
-    console.log(JSON.stringify(entry));
+    const line = `${JSON.stringify(entry)}\n`;
+    fs.writeSync(1, line);
   }
 }

--- a/packages/core/src/schema/docs.ts
+++ b/packages/core/src/schema/docs.ts
@@ -27,7 +27,11 @@ export const ENTRY_SCHEMA_DOC = {
       optional: true,
       fields: {
         modified: { type: "boolean" },
-        commits_touching_file: { type: "number" },
+        commits_touching_file: {
+          type: "number",
+          description:
+            "Best-effort count of commits after the comment. File-scoped when file lists are available; otherwise PR-wide.",
+        },
         latest_commit: { type: "string", optional: true },
         latest_commit_at: { type: "string", format: "date-time", optional: true },
       },

--- a/packages/core/tests/graphite.test.ts
+++ b/packages/core/tests/graphite.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test";
+
+import { parseGraphiteLog } from "../src/plugins/graphite";
+
+test("parseGraphiteLog builds a stack from gt log output", () => {
+  const output = [
+    "\u001B[36m\u25C9\u001B[39m feat/top (current) ",
+    "\u2502 PR #12 fix: top",
+    "\u25EF feat/base",
+    "\u2502 PR #11 fix: base",
+    "\u25EF main",
+  ].join("\n");
+
+  const stacks = parseGraphiteLog(output);
+  expect(stacks).toHaveLength(1);
+  expect(stacks[0]?.name).toBe("feat/base");
+  expect(stacks[0]?.branches.map((branch) => branch.prNumber)).toEqual([
+    11,
+    12,
+  ]);
+});

--- a/packages/core/tests/sync.test.ts
+++ b/packages/core/tests/sync.test.ts
@@ -1,0 +1,108 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { GitHubClient } from "../src/github";
+import type { FirewatchEntry, SyncMetadata } from "../src/schema/entry";
+
+const tempRoot = await mkdtemp(join(tmpdir(), "firewatch-sync-"));
+
+const { ensureDirectories, getRepoCachePath, readJsonl, writeJsonl, PATHS } =
+  await import("../src/cache");
+const { syncRepo } = await import("../src/sync");
+
+const originalPaths = { ...PATHS };
+
+afterAll(async () => {
+  Object.assign(PATHS as Record<string, string>, originalPaths);
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+Object.assign(PATHS as Record<string, string>, {
+  cache: join(tempRoot, "cache"),
+  config: join(tempRoot, "config"),
+  data: join(tempRoot, "data"),
+  repos: join(tempRoot, "cache", "repos"),
+  meta: join(tempRoot, "cache", "meta.jsonl"),
+  configFile: join(tempRoot, "config", "config.toml"),
+});
+
+await ensureDirectories();
+
+test("syncRepo uses last_sync when since is omitted", async () => {
+  const repo = "outfitter-dev/firewatch";
+  const lastSync = "2026-01-13T20:15:00.000Z";
+  const meta: SyncMetadata = {
+    repo,
+    last_sync: lastSync,
+    cursor: "cursor",
+    pr_count: 1,
+  };
+  await writeJsonl(PATHS.meta, [meta]);
+
+  type FetchOptions = Parameters<GitHubClient["fetchPRActivity"]>[2];
+  const calls: { after: string | null }[] = [];
+  const client = {
+    fetchPRActivity: (
+      _owner: string,
+      _repo: string,
+      options: FetchOptions = {}
+    ) => {
+      const optionsWithAfter = { after: null as string | null, ...options };
+      calls.push({ after: optionsWithAfter.after });
+      return Promise.resolve({
+        repository: {
+          pullRequests: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                number: 1,
+                title: "Sync test",
+                state: "OPEN",
+                isDraft: false,
+                author: { login: "alice" },
+                headRefName: "feat/sync",
+                createdAt: "2026-01-13T19:00:00.000Z",
+                updatedAt: "2026-01-13T20:30:00.000Z",
+                url: "https://github.com/outfitter-dev/firewatch/pull/1",
+                labels: { nodes: [] },
+                reviews: { nodes: [] },
+                comments: {
+                  nodes: [
+                    {
+                      id: "comment-1",
+                      author: { login: "alice" },
+                      body: "Old",
+                      createdAt: "2026-01-13T20:00:00.000Z",
+                      updatedAt: "2026-01-13T20:00:00.000Z",
+                    },
+                    {
+                      id: "comment-2",
+                      author: { login: "bob" },
+                      body: "New",
+                      createdAt: "2026-01-13T20:20:00.000Z",
+                      updatedAt: "2026-01-13T20:20:00.000Z",
+                    },
+                  ],
+                },
+                reviewThreads: { nodes: [] },
+                commits: { nodes: [] },
+              },
+            ],
+          },
+        },
+      });
+    },
+  } as GitHubClient;
+
+  const result = await syncRepo(client, repo);
+
+  expect(calls).toHaveLength(1);
+  expect(calls[0].after).toBeNull();
+  expect(result.prsProcessed).toBe(1);
+
+  const entries = await readJsonl<FirewatchEntry>(getRepoCachePath(repo));
+  expect(entries).toHaveLength(1);
+  expect(entries[0]?.id).toBe("comment-2");
+});


### PR DESCRIPTION
## Summary
- Use `last_sync` as the default incremental sync boundary and filter entries by updated/created timestamps.
- Extract shared CLI state/output helpers and tighten config show/local handling.
- Update docs (AGENTS header, GitHub/Graphite notes, config precedence) and schema docs for staleness scope.

## Testing
- bun run test
- bun run check
