### PR TITLE
feat: add fw todo and perspective filtering

### DIFF
--- a/apps/cli/src/commands/recap.ts
+++ b/apps/cli/src/commands/recap.ts
@@ -1,8 +1,12 @@
 import {
   type PrState,
+  buildAuthorIndex,
   buildWorklist,
+  getAuthorStatsSorted,
   queryEntries,
   sortWorklist,
+  type FirewatchEntry,
+  type WorklistEntry,
 } from "@outfitter/firewatch-core";
 import {
   getGraphiteStacks,
@@ -13,6 +17,165 @@ import { Command } from "commander";
 interface RecapCommandOptions {
   repo?: string;
   since?: string;
+}
+
+interface ReviewsByState {
+  approved: number;
+  changes_requested: number;
+  commented: number;
+  dismissed: number;
+}
+
+interface TopContributor {
+  author: string;
+  count: number;
+  isBot: boolean;
+}
+
+interface RecapSummary {
+  total: number;
+  totalComments: number;
+  totalReviews: number;
+  totalCommits: number;
+  needsResponse: WorklistEntry[];
+  ready: WorklistEntry[];
+  drafts: WorklistEntry[];
+  reviewsByState: ReviewsByState;
+  topContributors: TopContributor[];
+}
+
+function buildRecapSummary(
+  entries: FirewatchEntry[],
+  worklist: WorklistEntry[]
+): RecapSummary {
+  const needsResponse = worklist.filter(
+    (w) => (w.review_states?.changes_requested ?? 0) > 0
+  );
+  const ready = worklist.filter(
+    (w) =>
+      w.pr_state === "open" &&
+      (w.review_states?.approved ?? 0) > 0 &&
+      (w.review_states?.changes_requested ?? 0) === 0
+  );
+  const drafts = worklist.filter((w) => w.pr_state === "draft");
+  const totalComments = worklist.reduce(
+    (sum, w) => sum + w.counts.comments,
+    0
+  );
+
+  // Count reviews by state
+  const reviewsByState: ReviewsByState = {
+    approved: 0,
+    changes_requested: 0,
+    commented: 0,
+    dismissed: 0,
+  };
+  let totalReviews = 0;
+  let totalCommits = 0;
+
+  for (const entry of entries) {
+    if (entry.type === "review" && entry.state) {
+      totalReviews++;
+      const state = entry.state.toLowerCase();
+      if (state === "approved") {
+        reviewsByState.approved++;
+      } else if (state === "changes_requested") {
+        reviewsByState.changes_requested++;
+      } else if (state === "commented") {
+        reviewsByState.commented++;
+      } else if (state === "dismissed") {
+        reviewsByState.dismissed++;
+      }
+    } else if (entry.type === "commit") {
+      totalCommits++;
+    }
+  }
+
+  // Top contributors (excluding bots)
+  const authorIndex = buildAuthorIndex(entries);
+  const sortedAuthors = getAuthorStatsSorted(authorIndex);
+  const topContributors = sortedAuthors
+    .filter((a) => !a.isBot)
+    .slice(0, 5)
+    .map((a) => ({
+      author: a.author,
+      count: a.count,
+      isBot: a.isBot,
+    }));
+
+  return {
+    total: worklist.length,
+    totalComments,
+    totalReviews,
+    totalCommits,
+    needsResponse,
+    ready,
+    drafts,
+    reviewsByState,
+    topContributors,
+  };
+}
+
+function formatRecapGroup(
+  label: string,
+  items: WorklistEntry[]
+): string | null {
+  if (items.length === 0) {
+    return null;
+  }
+  const prs = items.slice(0, 5).map((w) => `#${w.pr}`).join(", ");
+  const more = items.length > 5 ? ` +${items.length - 5}` : "";
+  return `- ${label} (${items.length}): ${prs}${more}`;
+}
+
+function printRecapSummary(summary: RecapSummary): void {
+  console.log(
+    `Firewatch: ${summary.total} open PRs, ${summary.totalComments} comments, ${summary.totalReviews} reviews, ${summary.totalCommits} commits`
+  );
+
+  // PR status groups
+  const prLines = [
+    formatRecapGroup("Changes Requested", summary.needsResponse),
+    formatRecapGroup("Ready to Merge", summary.ready),
+    formatRecapGroup("Drafts", summary.drafts),
+  ].filter(Boolean);
+
+  if (prLines.length > 0) {
+    console.log("\nPR Status:");
+    for (const line of prLines) {
+      console.log(line);
+    }
+  }
+
+  // Reviews by state
+  const { reviewsByState } = summary;
+  const hasReviews =
+    reviewsByState.approved > 0 ||
+    reviewsByState.changes_requested > 0 ||
+    reviewsByState.commented > 0;
+
+  if (hasReviews) {
+    console.log("\nReviews by State:");
+    if (reviewsByState.approved > 0) {
+      console.log(`  approved: ${reviewsByState.approved}`);
+    }
+    if (reviewsByState.changes_requested > 0) {
+      console.log(`  changes_requested: ${reviewsByState.changes_requested}`);
+    }
+    if (reviewsByState.commented > 0) {
+      console.log(`  commented: ${reviewsByState.commented}`);
+    }
+  }
+
+  // Top contributors
+  if (summary.topContributors.length > 0) {
+    console.log("\nTop Contributors:");
+    for (const contrib of summary.topContributors) {
+      console.log(`  ${contrib.author}: ${contrib.count} items`);
+    }
+  }
+
+  console.log("\nRun `fw status --short` for JSONL output");
 }
 
 export const recapCommand = new Command("recap")
@@ -45,47 +208,8 @@ export const recapCommand = new Command("recap")
       }
 
       const worklist = sortWorklist(buildWorklist(enrichedEntries));
-
-      // Categorize PRs
-      const needsResponse = worklist.filter(
-        (w) => (w.review_states?.changes_requested ?? 0) > 0
-      );
-      const ready = worklist.filter(
-        (w) =>
-          w.pr_state === "open" &&
-          (w.review_states?.approved ?? 0) > 0 &&
-          (w.review_states?.changes_requested ?? 0) === 0
-      );
-      const drafts = worklist.filter((w) => w.pr_state === "draft");
-      const totalComments = worklist.reduce(
-        (sum, w) => sum + w.counts.comments,
-        0
-      );
-
-      // Header
-      console.log(`Firewatch: ${worklist.length} open PRs, ${totalComments} comments`);
-
-      // Categories as compact lines
-      if (needsResponse.length > 0) {
-        const prs = needsResponse.slice(0, 5).map((w) => `#${w.pr}`).join(", ");
-        const more = needsResponse.length > 5 ? ` +${needsResponse.length - 5}` : "";
-        console.log(`- Changes Requested (${needsResponse.length}): ${prs}${more}`);
-      }
-
-      if (ready.length > 0) {
-        const prs = ready.slice(0, 5).map((w) => `#${w.pr}`).join(", ");
-        const more = ready.length > 5 ? ` +${ready.length - 5}` : "";
-        console.log(`- Ready to Merge (${ready.length}): ${prs}${more}`);
-      }
-
-      if (drafts.length > 0) {
-        const prs = drafts.slice(0, 5).map((w) => `#${w.pr}`).join(", ");
-        const more = drafts.length > 5 ? ` +${drafts.length - 5}` : "";
-        console.log(`- Drafts (${drafts.length}): ${prs}${more}`);
-      }
-
-      // Footer
-      console.log(`\nRun \`fw status --short\` for JSONL output`);
+      const summary = buildRecapSummary(enrichedEntries, worklist);
+      printRecapSummary(summary);
     } catch (error) {
       console.error(
         "Recap failed:",

--- a/packages/core/src/authors.ts
+++ b/packages/core/src/authors.ts
@@ -1,0 +1,191 @@
+import type { FirewatchEntry } from "./schema/entry";
+
+/**
+ * Default patterns for detecting bot accounts.
+ * These patterns match common GitHub bot naming conventions.
+ */
+export const DEFAULT_BOT_PATTERNS = [
+  /\[bot\]$/i, // GitHub Apps (e.g., "dependabot[bot]")
+  /^github-actions/i, // GitHub Actions
+  /-bot$/i, // Generic bot suffix
+];
+
+/**
+ * Known bot accounts that don't match patterns.
+ * These are explicitly listed because they don't follow standard naming.
+ */
+export const DEFAULT_EXCLUDE_AUTHORS = [
+  "coderabbitai",
+  "greptile-apps",
+  "chatgpt-codex-connector",
+  "dependabot",
+  "renovate",
+  "codecov",
+  "netlify",
+  "vercel",
+];
+
+/**
+ * Check if an author matches bot patterns.
+ */
+export function isBot(
+  author: string,
+  patterns: readonly RegExp[] = DEFAULT_BOT_PATTERNS
+): boolean {
+  return patterns.some((pattern) => pattern.test(author));
+}
+
+/**
+ * Check if an author is in an exclusion list (case-insensitive).
+ */
+export function isExcludedAuthor(
+  author: string,
+  excludeList: readonly string[]
+): boolean {
+  const authorLower = author.toLowerCase();
+  return excludeList.some((excluded) => excluded.toLowerCase() === authorLower);
+}
+
+/**
+ * Check if an author should be excluded based on bot patterns and exclusion list.
+ */
+export function shouldExcludeAuthor(
+  author: string,
+  options: {
+    excludeList?: readonly string[];
+    botPatterns?: readonly RegExp[];
+    excludeBots?: boolean;
+  } = {}
+): boolean {
+  const {
+    excludeList = [],
+    botPatterns = DEFAULT_BOT_PATTERNS,
+    excludeBots = false,
+  } = options;
+
+  // Check explicit exclusion list first
+  if (isExcludedAuthor(author, excludeList)) {
+    return true;
+  }
+
+  // Check bot patterns if enabled
+  if (excludeBots && isBot(author, botPatterns)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Author statistics from entry analysis.
+ */
+export interface AuthorStats {
+  /** Author username */
+  author: string;
+  /** Total entry count */
+  count: number;
+  /** Entry counts by type */
+  types: Record<string, number>;
+  /** Whether the author is detected as a bot */
+  isBot: boolean;
+}
+
+/**
+ * Build an author index with statistics from entries.
+ * Useful for analyzing activity distribution and identifying bots.
+ */
+export function buildAuthorIndex(
+  entries: readonly FirewatchEntry[],
+  botPatterns: readonly RegExp[] = DEFAULT_BOT_PATTERNS
+): Map<string, AuthorStats> {
+  const index = new Map<string, AuthorStats>();
+
+  for (const entry of entries) {
+    const existing = index.get(entry.author);
+    if (existing) {
+      existing.count++;
+      existing.types[entry.type] = (existing.types[entry.type] ?? 0) + 1;
+    } else {
+      index.set(entry.author, {
+        author: entry.author,
+        count: 1,
+        types: { [entry.type]: 1 },
+        isBot: isBot(entry.author, botPatterns),
+      });
+    }
+  }
+
+  return index;
+}
+
+/**
+ * Get author statistics sorted by entry count (descending).
+ */
+export function getAuthorStatsSorted(
+  index: Map<string, AuthorStats>
+): AuthorStats[] {
+  return [...index.values()].toSorted((a, b) => b.count - a.count);
+}
+
+/**
+ * Options for author-based filtering.
+ */
+export interface AuthorFilterOptions {
+  /** Authors to explicitly exclude (case-insensitive) */
+  excludeAuthors?: readonly string[];
+  /** Exclude entries from detected bots */
+  excludeBots?: boolean;
+  /** Custom bot patterns (defaults to DEFAULT_BOT_PATTERNS) */
+  botPatterns?: readonly RegExp[];
+  /** Only include entries from this author (takes precedence) */
+  onlyAuthor?: string;
+}
+
+/**
+ * Filter entries by author criteria.
+ * Used for post-query filtering when advanced author logic is needed.
+ */
+export function filterByAuthor(
+  entries: readonly FirewatchEntry[],
+  options: AuthorFilterOptions
+): FirewatchEntry[] {
+  const {
+    excludeAuthors = [],
+    excludeBots = false,
+    botPatterns = DEFAULT_BOT_PATTERNS,
+    onlyAuthor,
+  } = options;
+
+  return entries.filter((entry) => {
+    // onlyAuthor filter takes precedence
+    if (onlyAuthor && entry.author.toLowerCase() !== onlyAuthor.toLowerCase()) {
+      return false;
+    }
+
+    // Skip exclusion checks if onlyAuthor is set
+    if (onlyAuthor) {
+      return true;
+    }
+
+    // Check exclusion criteria
+    return !shouldExcludeAuthor(entry.author, {
+      excludeList: excludeAuthors,
+      botPatterns,
+      excludeBots,
+    });
+  });
+}
+
+/**
+ * Merge default bot exclusions with custom list.
+ * Deduplicates and returns lowercase entries.
+ */
+export function mergeExcludeAuthors(
+  custom: readonly string[] = [],
+  includeDefaults = true
+): string[] {
+  const base = includeDefaults ? DEFAULT_EXCLUDE_AUTHORS : [];
+  const all = [...base, ...custom];
+  const unique = new Set(all.map((a) => a.toLowerCase()));
+  return [...unique];
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,21 @@
  * GitHub PR activity logger with pure JSONL output for jq-based workflows.
  */
 
+// Authors
+export {
+  DEFAULT_BOT_PATTERNS,
+  DEFAULT_EXCLUDE_AUTHORS,
+  buildAuthorIndex,
+  filterByAuthor,
+  getAuthorStatsSorted,
+  isBot,
+  isExcludedAuthor,
+  mergeExcludeAuthors,
+  shouldExcludeAuthor,
+  type AuthorFilterOptions,
+  type AuthorStats,
+} from "./authors";
+
 // Auth
 export { detectAuth, type AuthResult, type AuthSource } from "./auth";
 

--- a/packages/core/src/schema/config.ts
+++ b/packages/core/src/schema/config.ts
@@ -3,6 +3,30 @@ import { z } from "zod";
 import { PrStateSchema } from "./entry";
 
 /**
+ * Filter configuration for excluding authors/bots.
+ */
+export const FiltersConfigSchema = z.object({
+  /** Authors to exclude from queries (case-insensitive) */
+  exclude_authors: z.array(z.string()).default([]),
+  /** Additional bot patterns as regex strings (applied on top of defaults) */
+  bot_patterns: z.array(z.string()).default([]),
+  /** Exclude bots by default in queries */
+  exclude_bots: z.boolean().default(false),
+});
+
+export type FiltersConfig = z.infer<typeof FiltersConfigSchema>;
+
+/**
+ * User-specific configuration.
+ */
+export const UserConfigSchema = z.object({
+  /** GitHub username for perspective filtering (e.g., "mentions me") */
+  github_username: z.string().optional(),
+});
+
+export type UserConfig = z.infer<typeof UserConfigSchema>;
+
+/**
  * Firewatch configuration schema.
  * Stored in ~/.config/firewatch/config.toml (user) and .firewatch.toml (project)
  */
@@ -30,6 +54,12 @@ export const FirewatchConfigSchema = z.object({
 
   /** Staleness threshold for auto-sync before lookout (e.g., "1h", "30m") */
   lookout_stale_after: z.string().optional(),
+
+  /** Filter configuration for excluding authors/bots */
+  filters: FiltersConfigSchema.optional(),
+
+  /** User-specific configuration */
+  user: UserConfigSchema.optional(),
 });
 
 export type FirewatchConfig = z.infer<typeof FirewatchConfigSchema>;

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -1,7 +1,11 @@
 export {
   DEFAULT_CONFIG,
+  FiltersConfigSchema,
   FirewatchConfigSchema,
+  UserConfigSchema,
+  type FiltersConfig,
   type FirewatchConfig,
+  type UserConfig,
 } from "./config";
 
 export {


### PR DESCRIPTION
## Summary

- Add `fw todo` command for actionable item surfacing by category
- Add perspective filtering with `--for-me` and `--to-review` flags
- Add bot filtering and author exclusion support across commands
- Export lookout functions from core index for external use

## New Features

### `fw todo` Command
Surfaces actionable items organized by category:
- **unaddressed**: Review comments without replies
- **changes_requested**: PRs with requested changes
- **awaiting_review**: PRs waiting for review
- **stale**: PRs with no recent activity

### Perspective Filtering
- `--for-me`: Show my PRs that need my attention (feedback received, changes requested)
- `--to-review`: Show others' PRs that need my review

### Author Filtering
- `--exclude-bots` / `--humans`: Filter out bot activity (CodeRabbit, Greptile, etc.)
- `--exclude-author <names>`: Exclude specific authors from results
- Configurable bot patterns in `.firewatch.toml`

## Changes

- `apps/cli/src/commands/todo.ts`: New command implementation
- `apps/cli/src/commands/lookout.ts`: Add perspective filtering
- `apps/cli/src/commands/query.ts`: Add author filtering flags
- `apps/cli/src/commands/recap.ts`: Enhanced breakdown and top contributors
- `packages/core/src/authors.ts`: Bot detection and author filtering logic
- `packages/core/src/index.ts`: Export lookout and author functions

## Test plan

- [ ] Run `fw todo` and verify categorized output
- [ ] Run `fw todo --for-me` and verify perspective filtering
- [ ] Run `fw query --exclude-bots` and verify bot filtering
- [ ] Run `fw lookout --to-review` and verify review perspective

Closes #22, #25, #29, #30

🤖 Generated with [Claude Code](https://claude.ai/code)