### PR TITLE
feat(core): add SQLite database and repository layers

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1,0 +1,186 @@
+/**
+ * Database foundation for Firewatch.
+ *
+ * Provides SQLite database management using Bun's native sqlite driver.
+ * Uses WAL mode for better concurrent performance and schema versioning
+ * for future migrations.
+ */
+import { Database } from "bun:sqlite";
+
+/**
+ * Current schema version.
+ * Increment this when making schema changes and add migration logic.
+ */
+export const CURRENT_SCHEMA_VERSION = 1;
+
+/**
+ * Opens a SQLite database with optimal settings for Firewatch.
+ *
+ * @param path - Path to the database file. If omitted, creates an in-memory database.
+ * @returns Configured Database instance
+ */
+export function openDatabase(path?: string): Database {
+  const db = new Database(path ?? ":memory:", { create: true });
+
+  // Enable WAL mode for better concurrent read/write performance
+  db.exec("PRAGMA journal_mode = WAL");
+
+  // Set busy timeout to handle concurrent access gracefully
+  db.exec("PRAGMA busy_timeout = 5000");
+
+  // Enable foreign key enforcement
+  db.exec("PRAGMA foreign_keys = ON");
+
+  // Initialize schema if needed
+  initSchema(db);
+
+  return db;
+}
+
+/**
+ * Closes a database connection gracefully.
+ *
+ * @param db - Database instance to close
+ */
+export function closeDatabase(db: Database): void {
+  db.close();
+}
+
+/**
+ * Gets the current schema version from the database.
+ *
+ * @param db - Database instance
+ * @returns Current schema version (0 if not initialized)
+ */
+export function getSchemaVersion(db: Database): number {
+  const result = db
+    .query<{ user_version: number }, []>("PRAGMA user_version")
+    .get();
+  return result?.user_version ?? 0;
+}
+
+/**
+ * Sets the schema version in the database.
+ *
+ * @param db - Database instance
+ * @param version - Version number to set
+ */
+function setSchemaVersion(db: Database, version: number): void {
+  db.exec(`PRAGMA user_version = ${version}`);
+}
+
+/**
+ * SQL statements for creating the schema.
+ * Separated for clarity and potential reuse in migrations.
+ */
+const SCHEMA_SQL = `
+-- Mutable PR metadata (updated on each sync)
+CREATE TABLE IF NOT EXISTS prs (
+  repo TEXT NOT NULL,
+  number INTEGER NOT NULL,
+  node_id TEXT,
+  state TEXT NOT NULL,
+  is_draft INTEGER NOT NULL DEFAULT 0,
+  title TEXT,
+  author TEXT,
+  branch TEXT,
+  labels TEXT,
+  updated_at TEXT,
+  PRIMARY KEY (repo, number)
+);
+
+-- Immutable activity log
+-- Uses composite key (id, repo) to avoid potential ID collisions across repos
+CREATE TABLE IF NOT EXISTS entries (
+  id TEXT NOT NULL,
+  repo TEXT NOT NULL,
+  pr INTEGER NOT NULL,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  author TEXT,
+  body TEXT,
+  state TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT,
+  captured_at TEXT NOT NULL,
+  url TEXT,
+  file TEXT,
+  line INTEGER,
+  graphite_json TEXT,
+  file_activity_json TEXT,
+  file_provenance_json TEXT,
+  PRIMARY KEY (id, repo),
+  FOREIGN KEY (repo, pr) REFERENCES prs(repo, number)
+);
+
+-- Sync state (replaces meta.jsonl)
+CREATE TABLE IF NOT EXISTS sync_meta (
+  repo TEXT PRIMARY KEY,
+  cursor TEXT,
+  last_sync TEXT NOT NULL,
+  pr_count INTEGER NOT NULL DEFAULT 0
+);
+
+-- Performance indexes
+CREATE INDEX IF NOT EXISTS idx_entries_repo_pr ON entries(repo, pr);
+CREATE INDEX IF NOT EXISTS idx_entries_type ON entries(type);
+CREATE INDEX IF NOT EXISTS idx_entries_created ON entries(created_at);
+CREATE INDEX IF NOT EXISTS idx_entries_author ON entries(author);
+CREATE INDEX IF NOT EXISTS idx_prs_state ON prs(repo, state);
+CREATE INDEX IF NOT EXISTS idx_prs_author ON prs(repo, author);
+`;
+
+/**
+ * Initializes the database schema if not already present.
+ * Uses IF NOT EXISTS to be idempotent.
+ *
+ * @param db - Database instance
+ */
+export function initSchema(db: Database): void {
+  const currentVersion = getSchemaVersion(db);
+
+  if (currentVersion === 0) {
+    // Fresh database - create schema
+    db.exec(SCHEMA_SQL);
+    setSchemaVersion(db, CURRENT_SCHEMA_VERSION);
+  } else if (currentVersion < CURRENT_SCHEMA_VERSION) {
+    // Existing database needs migration
+    migrateSchema(db, CURRENT_SCHEMA_VERSION);
+  }
+  // If currentVersion >= CURRENT_SCHEMA_VERSION, schema is up to date
+}
+
+/**
+ * Migrates the database schema from current version to target version.
+ * Each version increment should have its own migration logic.
+ *
+ * @param db - Database instance
+ * @param targetVersion - Target schema version
+ */
+export function migrateSchema(db: Database, targetVersion: number): void {
+  const currentVersion = getSchemaVersion(db);
+
+  if (currentVersion >= targetVersion) {
+    return; // Already at or past target version
+  }
+
+  // Run migrations in a transaction for atomicity
+  db.transaction(() => {
+    let version = currentVersion;
+
+    // Add migration cases as schema evolves
+    // Example for future migrations:
+    // if (version === 1 && targetVersion >= 2) {
+    //   db.exec("ALTER TABLE entries ADD COLUMN new_field TEXT");
+    //   version = 2;
+    // }
+
+    // For version 0 -> 1, we just create the schema
+    if (version === 0 && targetVersion >= 1) {
+      db.exec(SCHEMA_SQL);
+      version = 1;
+    }
+
+    setSchemaVersion(db, version);
+  })();
+}

--- a/packages/core/src/repository.ts
+++ b/packages/core/src/repository.ts
@@ -1,0 +1,904 @@
+/**
+ * Repository layer for Firewatch SQLite database.
+ *
+ * Provides type-safe CRUD operations for entries, PRs, and sync metadata.
+ * All operations use prepared statements for safety and performance.
+ */
+import type { Database, Statement } from "bun:sqlite";
+
+import type { QueryFilters } from "./query";
+import type {
+  EntryType,
+  FileActivityAfter,
+  FileProvenance,
+  FirewatchEntry,
+  GraphiteMetadata,
+  PrState,
+  SyncMetadata,
+} from "./schema/entry";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * PR metadata stored in the database (mutable state).
+ * This is the source of truth for PR state, updated on each sync.
+ */
+export interface PRMetadata {
+  repo: string;
+  number: number;
+  nodeId?: string | undefined;
+  state: "open" | "closed" | "merged";
+  isDraft: boolean;
+  title?: string | undefined;
+  author?: string | undefined;
+  branch?: string | undefined;
+  labels: string[];
+  updatedAt?: string | undefined;
+}
+
+/**
+ * Database row type for entries table.
+ * JSON fields are stored as TEXT.
+ */
+interface EntryRow {
+  id: string;
+  repo: string;
+  pr: number;
+  type: EntryType;
+  subtype: string | null;
+  author: string;
+  body: string | null;
+  state: string | null;
+  created_at: string;
+  updated_at: string | null;
+  captured_at: string;
+  url: string | null;
+  file: string | null;
+  line: number | null;
+  graphite_json: string | null;
+  file_activity_json: string | null;
+  file_provenance_json: string | null;
+}
+
+/**
+ * Database row type for prs table.
+ */
+interface PRRow {
+  repo: string;
+  number: number;
+  node_id: string | null;
+  state: string;
+  is_draft: number;
+  title: string | null;
+  author: string | null;
+  branch: string | null;
+  labels: string | null;
+  updated_at: string | null;
+}
+
+/**
+ * Database row type for sync_meta table.
+ */
+interface SyncMetaRow {
+  repo: string;
+  cursor: string | null;
+  last_sync: string;
+  pr_count: number;
+}
+
+/**
+ * Joined row type for entry queries with PR data.
+ */
+interface EntryWithPRRow extends EntryRow {
+  pr_state: string;
+  pr_is_draft: number;
+  pr_title: string | null;
+  pr_author: string | null;
+  pr_branch: string | null;
+  pr_labels: string | null;
+}
+
+/**
+ * Partial updates for entries (e.g., file activity updates).
+ */
+export interface EntryUpdates {
+  body?: string;
+  state?: string;
+  updated_at?: string;
+  file_activity_after?: FileActivityAfter;
+}
+
+// =============================================================================
+// Prepared Statement Cache
+// =============================================================================
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Bun's SQLite types are too strict for dynamic bindings
+type AnyStatement = Statement<any, any>;
+
+const statementCache = new WeakMap<Database, Map<string, AnyStatement>>();
+
+/**
+ * Get or create a prepared statement for the given database and SQL.
+ */
+function getStatement(db: Database, name: string, sql: string): AnyStatement {
+  let cache = statementCache.get(db);
+  if (!cache) {
+    cache = new Map();
+    statementCache.set(db, cache);
+  }
+
+  let stmt = cache.get(name);
+  if (!stmt) {
+    stmt = db.prepare(sql);
+    cache.set(name, stmt);
+  }
+  return stmt;
+}
+
+// =============================================================================
+// Conversion Functions
+// =============================================================================
+
+/**
+ * Convert a FirewatchEntry to a database row.
+ * Serializes nested objects to JSON.
+ */
+function entryToRow(entry: FirewatchEntry): EntryRow {
+  return {
+    id: entry.id,
+    repo: entry.repo,
+    pr: entry.pr,
+    type: entry.type,
+    subtype: entry.subtype ?? null,
+    author: entry.author,
+    body: entry.body ?? null,
+    state: entry.state ?? null,
+    created_at: entry.created_at,
+    updated_at: entry.updated_at ?? null,
+    captured_at: entry.captured_at,
+    url: entry.url ?? null,
+    file: entry.file ?? null,
+    line: entry.line ?? null,
+    graphite_json: entry.graphite ? JSON.stringify(entry.graphite) : null,
+    file_activity_json: entry.file_activity_after
+      ? JSON.stringify(entry.file_activity_after)
+      : null,
+    file_provenance_json: entry.file_provenance
+      ? JSON.stringify(entry.file_provenance)
+      : null,
+  };
+}
+
+/**
+ * Derive the display PR state from PR metadata.
+ * Draft PRs show as "draft" even though the underlying state is "open".
+ */
+function derivePrState(prState: string, isDraft: boolean): PrState {
+  if (isDraft) {
+    return "draft";
+  }
+  return prState as PrState;
+}
+
+/**
+ * Convert a joined database row (entry + PR) to a FirewatchEntry.
+ * This is the critical function that computes pr_state from current PR metadata.
+ */
+export function rowToEntry(row: EntryWithPRRow): FirewatchEntry {
+  const entry: FirewatchEntry = {
+    id: row.id,
+    repo: row.repo,
+    pr: row.pr,
+    pr_title: row.pr_title ?? "",
+    pr_state: derivePrState(row.pr_state, row.pr_is_draft === 1),
+    pr_author: row.pr_author ?? "unknown",
+    pr_branch: row.pr_branch ?? "",
+    type: row.type,
+    author: row.author,
+    created_at: row.created_at,
+    captured_at: row.captured_at,
+  };
+
+  // Optional PR labels
+  if (row.pr_labels) {
+    try {
+      const labels = JSON.parse(row.pr_labels) as string[];
+      if (labels.length > 0) {
+        entry.pr_labels = labels;
+      }
+    } catch {
+      // Ignore parse errors, leave pr_labels undefined
+    }
+  }
+
+  // Optional entry fields
+  if (row.subtype) {
+    entry.subtype = row.subtype;
+  }
+  if (row.body) {
+    entry.body = row.body;
+  }
+  if (row.state) {
+    entry.state = row.state;
+  }
+  if (row.updated_at) {
+    entry.updated_at = row.updated_at;
+  }
+  if (row.url) {
+    entry.url = row.url;
+  }
+  if (row.file) {
+    entry.file = row.file;
+  }
+  if (row.line !== null) {
+    entry.line = row.line;
+  }
+
+  // Deserialize JSON fields
+  if (row.graphite_json) {
+    try {
+      entry.graphite = JSON.parse(row.graphite_json) as GraphiteMetadata;
+    } catch {
+      // Ignore parse errors
+    }
+  }
+  if (row.file_activity_json) {
+    try {
+      entry.file_activity_after = JSON.parse(
+        row.file_activity_json
+      ) as FileActivityAfter;
+    } catch {
+      // Ignore parse errors
+    }
+  }
+  if (row.file_provenance_json) {
+    try {
+      entry.file_provenance = JSON.parse(
+        row.file_provenance_json
+      ) as FileProvenance;
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  return entry;
+}
+
+/**
+ * Convert a PR database row to PRMetadata.
+ */
+function rowToPRMetadata(row: PRRow): PRMetadata {
+  let labels: string[] = [];
+  if (row.labels) {
+    try {
+      labels = JSON.parse(row.labels) as string[];
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  return {
+    repo: row.repo,
+    number: row.number,
+    nodeId: row.node_id ?? undefined,
+    state: row.state as "open" | "closed" | "merged",
+    isDraft: row.is_draft === 1,
+    title: row.title ?? undefined,
+    author: row.author ?? undefined,
+    branch: row.branch ?? undefined,
+    labels,
+    updatedAt: row.updated_at ?? undefined,
+  };
+}
+
+/**
+ * Convert PRMetadata to parameters for database insert.
+ */
+function prMetadataToParams(pr: PRMetadata): Record<string, unknown> {
+  return {
+    $repo: pr.repo,
+    $number: pr.number,
+    $node_id: pr.nodeId ?? null,
+    $state: pr.state,
+    $is_draft: pr.isDraft ? 1 : 0,
+    $title: pr.title ?? null,
+    $author: pr.author ?? null,
+    $branch: pr.branch ?? null,
+    $labels: pr.labels.length > 0 ? JSON.stringify(pr.labels) : null,
+    $updated_at: pr.updatedAt ?? null,
+  };
+}
+
+// =============================================================================
+// Entry Operations
+// =============================================================================
+
+const INSERT_ENTRY_SQL = `
+  INSERT OR REPLACE INTO entries
+  (id, repo, pr, type, subtype, author, body, state, created_at, updated_at,
+   captured_at, url, file, line, graphite_json, file_activity_json, file_provenance_json)
+  VALUES ($id, $repo, $pr, $type, $subtype, $author, $body, $state, $created_at,
+          $updated_at, $captured_at, $url, $file, $line, $graphite_json,
+          $file_activity_json, $file_provenance_json)
+`;
+
+/**
+ * Insert a single entry into the database.
+ * Uses INSERT OR REPLACE to handle re-syncs.
+ */
+export function insertEntry(db: Database, entry: FirewatchEntry): void {
+  const stmt = getStatement(db, "insertEntry", INSERT_ENTRY_SQL);
+  const row = entryToRow(entry);
+
+  stmt.run({
+    $id: row.id,
+    $repo: row.repo,
+    $pr: row.pr,
+    $type: row.type,
+    $subtype: row.subtype,
+    $author: row.author,
+    $body: row.body,
+    $state: row.state,
+    $created_at: row.created_at,
+    $updated_at: row.updated_at,
+    $captured_at: row.captured_at,
+    $url: row.url,
+    $file: row.file,
+    $line: row.line,
+    $graphite_json: row.graphite_json,
+    $file_activity_json: row.file_activity_json,
+    $file_provenance_json: row.file_provenance_json,
+  });
+}
+
+/**
+ * Insert multiple entries in a single transaction.
+ * More efficient than individual inserts for bulk operations.
+ */
+export function insertEntries(db: Database, entries: FirewatchEntry[]): void {
+  if (entries.length === 0) {
+    return;
+  }
+
+  const stmt = getStatement(db, "insertEntry", INSERT_ENTRY_SQL);
+
+  const insertAll = db.transaction(() => {
+    for (const entry of entries) {
+      const row = entryToRow(entry);
+      stmt.run({
+        $id: row.id,
+        $repo: row.repo,
+        $pr: row.pr,
+        $type: row.type,
+        $subtype: row.subtype,
+        $author: row.author,
+        $body: row.body,
+        $state: row.state,
+        $created_at: row.created_at,
+        $updated_at: row.updated_at,
+        $captured_at: row.captured_at,
+        $url: row.url,
+        $file: row.file,
+        $line: row.line,
+        $graphite_json: row.graphite_json,
+        $file_activity_json: row.file_activity_json,
+        $file_provenance_json: row.file_provenance_json,
+      });
+    }
+  });
+
+  insertAll();
+}
+
+/**
+ * Build state filter conditions from PrState array.
+ * Handles the complexity of draft being a special case (is_draft flag vs state column).
+ */
+function buildStateConditions(
+  states: PrState[],
+  params: Record<string, unknown>
+): string | null {
+  if (states.length === 0) {
+    return null;
+  }
+
+  const stateConditions: string[] = [];
+  const nonDraftStates: string[] = [];
+
+  for (const state of states) {
+    if (state === "draft") {
+      stateConditions.push("p.is_draft = 1");
+    } else if (state === "open") {
+      // "open" means state is open AND not draft
+      stateConditions.push("(p.state = 'open' AND p.is_draft = 0)");
+    } else {
+      nonDraftStates.push(state);
+    }
+  }
+
+  if (nonDraftStates.length > 0) {
+    const placeholders = nonDraftStates.map((_, i) => `$state_${i}`).join(", ");
+    stateConditions.push(`p.state IN (${placeholders})`);
+    for (const [i, state] of nonDraftStates.entries()) {
+      params[`$state_${i}`] = state;
+    }
+  }
+
+  return stateConditions.length > 0
+    ? `(${stateConditions.join(" OR ")})`
+    : null;
+}
+
+/**
+ * Build a dynamic WHERE clause from QueryFilters.
+ * Returns the SQL fragment and parameter object.
+ */
+function buildWhereClause(filters: QueryFilters): {
+  sql: string;
+  params: Record<string, unknown>;
+} {
+  const conditions: string[] = [];
+  const params: Record<string, unknown> = {};
+
+  if (filters.id) {
+    conditions.push("e.id = $id");
+    params.$id = filters.id;
+  }
+
+  if (filters.repo) {
+    conditions.push("e.repo LIKE $repo");
+    params.$repo = `%${filters.repo}%`;
+  }
+
+  if (filters.pr !== undefined) {
+    conditions.push("e.pr = $pr");
+    params.$pr = filters.pr;
+  }
+
+  if (filters.prs?.length) {
+    const placeholders = filters.prs.map((_, i) => `$pr_${i}`).join(", ");
+    conditions.push(`e.pr IN (${placeholders})`);
+    for (const [i, pr] of filters.prs.entries()) {
+      params[`$pr_${i}`] = pr;
+    }
+  }
+
+  if (filters.author) {
+    conditions.push("e.author = $author");
+    params.$author = filters.author;
+  }
+
+  if (filters.type) {
+    const types = Array.isArray(filters.type) ? filters.type : [filters.type];
+    const placeholders = types.map((_, i) => `$type_${i}`).join(", ");
+    conditions.push(`e.type IN (${placeholders})`);
+    for (const [i, type] of types.entries()) {
+      params[`$type_${i}`] = type;
+    }
+  }
+
+  if (filters.states?.length) {
+    const stateCondition = buildStateConditions(filters.states, params);
+    if (stateCondition) {
+      conditions.push(stateCondition);
+    }
+  }
+
+  if (filters.label) {
+    // Use json_each to search within the labels JSON array
+    conditions.push(`
+      EXISTS (
+        SELECT 1 FROM json_each(p.labels) AS label
+        WHERE LOWER(label.value) LIKE $label
+      )
+    `);
+    params.$label = `%${filters.label.toLowerCase()}%`;
+  }
+
+  if (filters.since) {
+    conditions.push("e.created_at >= $since");
+    params.$since = filters.since.toISOString();
+  }
+
+  return {
+    sql: conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "",
+    params,
+  };
+}
+
+/**
+ * Query entries with filters, joining with PR table for current state.
+ * This is the primary query function that returns entries with up-to-date PR state.
+ */
+export function queryEntries(
+  db: Database,
+  filters: QueryFilters = {}
+): FirewatchEntry[] {
+  const { sql: whereClause, params } = buildWhereClause(filters);
+
+  const query = `
+    SELECT
+      e.id, e.repo, e.pr, e.type, e.subtype, e.author, e.body, e.state,
+      e.created_at, e.updated_at, e.captured_at, e.url, e.file, e.line,
+      e.graphite_json, e.file_activity_json, e.file_provenance_json,
+      p.state AS pr_state, p.is_draft AS pr_is_draft,
+      p.title AS pr_title, p.author AS pr_author,
+      p.branch AS pr_branch, p.labels AS pr_labels
+    FROM entries e
+    JOIN prs p ON e.repo = p.repo AND e.pr = p.number
+    ${whereClause}
+    ORDER BY e.created_at DESC
+  `;
+
+  const stmt = db.prepare(query);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Dynamic SQL params
+  const rows = stmt.all(params as any) as EntryWithPRRow[];
+
+  return rows.map(rowToEntry);
+}
+
+/**
+ * Update specific fields of an entry.
+ * Useful for file activity updates.
+ */
+export function updateEntry(
+  db: Database,
+  id: string,
+  repo: string,
+  updates: EntryUpdates
+): void {
+  const setClauses: string[] = [];
+  const params: Record<string, unknown> = { $id: id, $repo: repo };
+
+  if (updates.body !== undefined) {
+    setClauses.push("body = $body");
+    params.$body = updates.body;
+  }
+
+  if (updates.state !== undefined) {
+    setClauses.push("state = $state");
+    params.$state = updates.state;
+  }
+
+  if (updates.updated_at !== undefined) {
+    setClauses.push("updated_at = $updated_at");
+    params.$updated_at = updates.updated_at;
+  }
+
+  if (updates.file_activity_after !== undefined) {
+    setClauses.push("file_activity_json = $file_activity_json");
+    params.$file_activity_json = JSON.stringify(updates.file_activity_after);
+  }
+
+  if (setClauses.length === 0) {
+    return;
+  }
+
+  const sql = `UPDATE entries SET ${setClauses.join(", ")} WHERE id = $id AND repo = $repo`;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Dynamic SQL params
+  db.prepare(sql).run(params as any);
+}
+
+/**
+ * Delete all entries for a repository.
+ * Useful for full refresh scenarios.
+ */
+export function deleteEntriesByRepo(db: Database, repo: string): void {
+  const stmt = getStatement(
+    db,
+    "deleteEntriesByRepo",
+    "DELETE FROM entries WHERE repo = $repo"
+  );
+  stmt.run({ $repo: repo });
+}
+
+/**
+ * Get an entry by ID and repo.
+ */
+export function getEntry(
+  db: Database,
+  id: string,
+  repo: string
+): FirewatchEntry | null {
+  const query = `
+    SELECT
+      e.id, e.repo, e.pr, e.type, e.subtype, e.author, e.body, e.state,
+      e.created_at, e.updated_at, e.captured_at, e.url, e.file, e.line,
+      e.graphite_json, e.file_activity_json, e.file_provenance_json,
+      p.state AS pr_state, p.is_draft AS pr_is_draft,
+      p.title AS pr_title, p.author AS pr_author,
+      p.branch AS pr_branch, p.labels AS pr_labels
+    FROM entries e
+    JOIN prs p ON e.repo = p.repo AND e.pr = p.number
+    WHERE e.id = $id AND e.repo = $repo
+  `;
+
+  const stmt = db.prepare(query);
+  const row = stmt.get({ $id: id, $repo: repo }) as EntryWithPRRow | null;
+
+  return row ? rowToEntry(row) : null;
+}
+
+// =============================================================================
+// PR Metadata Operations
+// =============================================================================
+
+const UPSERT_PR_SQL = `
+  INSERT INTO prs (repo, number, node_id, state, is_draft, title, author, branch, labels, updated_at)
+  VALUES ($repo, $number, $node_id, $state, $is_draft, $title, $author, $branch, $labels, $updated_at)
+  ON CONFLICT(repo, number) DO UPDATE SET
+    node_id = excluded.node_id,
+    state = excluded.state,
+    is_draft = excluded.is_draft,
+    title = excluded.title,
+    author = excluded.author,
+    branch = excluded.branch,
+    labels = excluded.labels,
+    updated_at = excluded.updated_at
+`;
+
+/**
+ * Insert or update a PR's metadata.
+ * This is the key function that keeps PR state fresh.
+ */
+export function upsertPR(db: Database, pr: PRMetadata): void {
+  const stmt = getStatement(db, "upsertPR", UPSERT_PR_SQL);
+  stmt.run(prMetadataToParams(pr));
+}
+
+/**
+ * Insert or update multiple PRs in a single transaction.
+ */
+export function upsertPRs(db: Database, prs: PRMetadata[]): void {
+  if (prs.length === 0) {
+    return;
+  }
+
+  const stmt = getStatement(db, "upsertPR", UPSERT_PR_SQL);
+
+  const upsertAll = db.transaction(() => {
+    for (const pr of prs) {
+      stmt.run(prMetadataToParams(pr));
+    }
+  });
+
+  upsertAll();
+}
+
+/**
+ * Get PR metadata by repo and number.
+ */
+export function getPR(
+  db: Database,
+  repo: string,
+  number: number
+): PRMetadata | null {
+  const stmt = getStatement(
+    db,
+    "getPR",
+    "SELECT * FROM prs WHERE repo = $repo AND number = $number"
+  );
+  const row = stmt.get({ $repo: repo, $number: number }) as PRRow | null;
+
+  return row ? rowToPRMetadata(row) : null;
+}
+
+/**
+ * Get all PRs for a repository matching given states.
+ */
+export function getPRsByState(
+  db: Database,
+  repo: string,
+  states: PrState[]
+): PRMetadata[] {
+  if (states.length === 0) {
+    return [];
+  }
+
+  // Build dynamic state conditions
+  const conditions: string[] = ["repo = $repo"];
+  const params: Record<string, unknown> = { $repo: repo };
+
+  const stateConditions: string[] = [];
+  const nonDraftStates: string[] = [];
+
+  for (const state of states) {
+    if (state === "draft") {
+      stateConditions.push("is_draft = 1");
+    } else if (state === "open") {
+      stateConditions.push("(state = 'open' AND is_draft = 0)");
+    } else {
+      nonDraftStates.push(state);
+    }
+  }
+
+  if (nonDraftStates.length > 0) {
+    const placeholders = nonDraftStates.map((_, i) => `$state_${i}`).join(", ");
+    stateConditions.push(`state IN (${placeholders})`);
+    for (const [i, state] of nonDraftStates.entries()) {
+      params[`$state_${i}`] = state;
+    }
+  }
+
+  if (stateConditions.length > 0) {
+    conditions.push(`(${stateConditions.join(" OR ")})`);
+  }
+
+  const sql = `SELECT * FROM prs WHERE ${conditions.join(" AND ")}`;
+  const stmt = db.prepare(sql);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Dynamic SQL params
+  const rows = stmt.all(params as any) as PRRow[];
+
+  return rows.map(rowToPRMetadata);
+}
+
+/**
+ * Update the state of a PR.
+ */
+export function updatePRState(
+  db: Database,
+  repo: string,
+  number: number,
+  state: PrState
+): void {
+  const isDraft = state === "draft";
+  const dbState = isDraft ? "open" : state;
+
+  const stmt = getStatement(
+    db,
+    "updatePRState",
+    "UPDATE prs SET state = $state, is_draft = $is_draft WHERE repo = $repo AND number = $number"
+  );
+
+  stmt.run({
+    $repo: repo,
+    $number: number,
+    $state: dbState,
+    $is_draft: isDraft ? 1 : 0,
+  });
+}
+
+/**
+ * Delete a PR and all its entries (cascade).
+ */
+export function deletePR(db: Database, repo: string, number: number): void {
+  // Delete entries first (foreign key constraint)
+  db.prepare("DELETE FROM entries WHERE repo = $repo AND pr = $pr").run({
+    $repo: repo,
+    $pr: number,
+  });
+
+  // Then delete PR
+  db.prepare("DELETE FROM prs WHERE repo = $repo AND number = $number").run({
+    $repo: repo,
+    $number: number,
+  });
+}
+
+// =============================================================================
+// Sync Metadata Operations
+// =============================================================================
+
+/**
+ * Get sync metadata for a repository.
+ */
+export function getSyncMeta(db: Database, repo: string): SyncMetadata | null {
+  const stmt = getStatement(
+    db,
+    "getSyncMeta",
+    "SELECT * FROM sync_meta WHERE repo = $repo"
+  );
+  const row = stmt.get({ $repo: repo }) as SyncMetaRow | null;
+
+  if (!row) {
+    return null;
+  }
+
+  return {
+    repo: row.repo,
+    cursor: row.cursor ?? undefined,
+    last_sync: row.last_sync,
+    pr_count: row.pr_count,
+  };
+}
+
+/**
+ * Set sync metadata for a repository (upsert).
+ */
+export function setSyncMeta(db: Database, meta: SyncMetadata): void {
+  const stmt = getStatement(
+    db,
+    "setSyncMeta",
+    `
+    INSERT INTO sync_meta (repo, cursor, last_sync, pr_count)
+    VALUES ($repo, $cursor, $last_sync, $pr_count)
+    ON CONFLICT(repo) DO UPDATE SET
+      cursor = excluded.cursor,
+      last_sync = excluded.last_sync,
+      pr_count = excluded.pr_count
+  `
+  );
+
+  stmt.run({
+    $repo: meta.repo,
+    $cursor: meta.cursor ?? null,
+    $last_sync: meta.last_sync,
+    $pr_count: meta.pr_count,
+  });
+}
+
+/**
+ * Delete sync metadata for a repository.
+ */
+export function deleteSyncMeta(db: Database, repo: string): void {
+  const stmt = getStatement(
+    db,
+    "deleteSyncMeta",
+    "DELETE FROM sync_meta WHERE repo = $repo"
+  );
+  stmt.run({ $repo: repo });
+}
+
+/**
+ * Get all sync metadata (all repos).
+ */
+export function getAllSyncMeta(db: Database): SyncMetadata[] {
+  const stmt = db.prepare("SELECT * FROM sync_meta");
+  const rows = stmt.all() as SyncMetaRow[];
+
+  return rows.map((row) => ({
+    repo: row.repo,
+    cursor: row.cursor ?? undefined,
+    last_sync: row.last_sync,
+    pr_count: row.pr_count,
+  }));
+}
+
+// =============================================================================
+// Utility Operations
+// =============================================================================
+
+/**
+ * Count entries matching filters.
+ */
+export function countEntries(db: Database, filters: QueryFilters = {}): number {
+  const { sql: whereClause, params } = buildWhereClause(filters);
+
+  const query = `
+    SELECT COUNT(*) AS count
+    FROM entries e
+    JOIN prs p ON e.repo = p.repo AND e.pr = p.number
+    ${whereClause}
+  `;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Dynamic SQL params
+  const result = db.prepare(query).get(params as any) as {
+    count: number;
+  } | null;
+  return result?.count ?? 0;
+}
+
+/**
+ * Get distinct repos from the entries table.
+ */
+export function getRepos(db: Database): string[] {
+  const stmt = db.prepare("SELECT DISTINCT repo FROM entries ORDER BY repo");
+  const rows = stmt.all() as { repo: string }[];
+  return rows.map((row) => row.repo);
+}
+
+/**
+ * Clear all data for a repository (entries, PR, sync meta).
+ * Useful for full refresh.
+ */
+export function clearRepo(db: Database, repo: string): void {
+  const clearAll = db.transaction(() => {
+    db.prepare("DELETE FROM entries WHERE repo = $repo").run({ $repo: repo });
+    db.prepare("DELETE FROM prs WHERE repo = $repo").run({ $repo: repo });
+    db.prepare("DELETE FROM sync_meta WHERE repo = $repo").run({ $repo: repo });
+  });
+
+  clearAll();
+}

--- a/packages/core/tests/db.test.ts
+++ b/packages/core/tests/db.test.ts
@@ -1,0 +1,248 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  closeDatabase,
+  CURRENT_SCHEMA_VERSION,
+  getSchemaVersion,
+  initSchema,
+  migrateSchema,
+  openDatabase,
+} from "../src/db";
+
+const tempRoot = await mkdtemp(join(tmpdir(), "firewatch-db-"));
+
+afterAll(async () => {
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+test("openDatabase creates a working database with WAL mode", () => {
+  const dbPath = join(tempRoot, "test-wal.db");
+  const db = openDatabase(dbPath);
+
+  // Verify WAL mode is enabled
+  const journalMode = db
+    .query<{ journal_mode: string }, []>("PRAGMA journal_mode")
+    .get();
+  expect(journalMode?.journal_mode).toBe("wal");
+
+  closeDatabase(db);
+});
+
+test("openDatabase creates in-memory database when path is omitted", () => {
+  const db = openDatabase();
+
+  // Verify database is functional
+  db.exec("CREATE TABLE test_table (id INTEGER PRIMARY KEY)");
+  db.exec("INSERT INTO test_table (id) VALUES (1)");
+  const result = db
+    .query<{ id: number }, []>("SELECT id FROM test_table")
+    .get();
+  expect(result?.id).toBe(1);
+
+  closeDatabase(db);
+});
+
+test("schema is initialized with correct tables", () => {
+  const db = openDatabase();
+
+  // Check that required tables exist
+  const tables = db
+    .query<{ name: string }, []>(
+      "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+    )
+    .all();
+  const tableNames = tables.map((t) => t.name);
+
+  expect(tableNames).toContain("prs");
+  expect(tableNames).toContain("entries");
+  expect(tableNames).toContain("sync_meta");
+
+  closeDatabase(db);
+});
+
+test("schema has correct indexes", () => {
+  const db = openDatabase();
+
+  const indexes = db
+    .query<{ name: string }, []>(
+      "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_%' ORDER BY name"
+    )
+    .all();
+  const indexNames = indexes.map((i) => i.name);
+
+  expect(indexNames).toContain("idx_entries_repo_pr");
+  expect(indexNames).toContain("idx_entries_type");
+  expect(indexNames).toContain("idx_entries_created");
+  expect(indexNames).toContain("idx_entries_author");
+  expect(indexNames).toContain("idx_prs_state");
+  expect(indexNames).toContain("idx_prs_author");
+
+  closeDatabase(db);
+});
+
+test("getSchemaVersion returns current version after init", () => {
+  const db = openDatabase();
+
+  const version = getSchemaVersion(db);
+  expect(version).toBe(CURRENT_SCHEMA_VERSION);
+
+  closeDatabase(db);
+});
+
+test("initSchema is idempotent", () => {
+  const db = openDatabase();
+
+  // Call initSchema multiple times
+  initSchema(db);
+  initSchema(db);
+  initSchema(db);
+
+  // Should still work with correct version
+  const version = getSchemaVersion(db);
+  expect(version).toBe(CURRENT_SCHEMA_VERSION);
+
+  closeDatabase(db);
+});
+
+test("migrateSchema handles already-migrated database", () => {
+  const db = openDatabase();
+
+  // Migrate to current version (should be no-op)
+  migrateSchema(db, CURRENT_SCHEMA_VERSION);
+
+  const version = getSchemaVersion(db);
+  expect(version).toBe(CURRENT_SCHEMA_VERSION);
+
+  closeDatabase(db);
+});
+
+test("prs table has correct schema", () => {
+  const db = openDatabase();
+
+  // Insert a PR
+  const insertPr = db.prepare(`
+    INSERT INTO prs (repo, number, node_id, state, is_draft, title, author, branch, labels, updated_at)
+    VALUES ($repo, $number, $node_id, $state, $is_draft, $title, $author, $branch, $labels, $updated_at)
+  `);
+
+  insertPr.run({
+    $repo: "owner/repo",
+    $number: 1,
+    $node_id: "PR_123",
+    $state: "open",
+    $is_draft: 0,
+    $title: "Test PR",
+    $author: "testuser",
+    $branch: "feature/test",
+    $labels: '["bug", "enhancement"]',
+    $updated_at: "2025-01-15T00:00:00Z",
+  });
+
+  // Verify retrieval
+  const pr = db
+    .query<
+      {
+        repo: string;
+        number: number;
+        state: string;
+        title: string;
+      },
+      []
+    >("SELECT repo, number, state, title FROM prs WHERE number = 1")
+    .get();
+
+  expect(pr?.repo).toBe("owner/repo");
+  expect(pr?.number).toBe(1);
+  expect(pr?.state).toBe("open");
+  expect(pr?.title).toBe("Test PR");
+
+  closeDatabase(db);
+});
+
+test("entries table has correct schema and foreign key", () => {
+  const db = openDatabase();
+
+  // First insert a PR (required for foreign key)
+  db.prepare(`
+    INSERT INTO prs (repo, number, state, is_draft)
+    VALUES ($repo, $number, $state, $is_draft)
+  `).run({
+    $repo: "owner/repo",
+    $number: 1,
+    $state: "open",
+    $is_draft: 0,
+  });
+
+  // Insert an entry
+  const insertEntry = db.prepare(`
+    INSERT INTO entries (id, repo, pr, type, subtype, author, body, created_at, captured_at, url)
+    VALUES ($id, $repo, $pr, $type, $subtype, $author, $body, $created_at, $captured_at, $url)
+  `);
+
+  insertEntry.run({
+    $id: "comment-123",
+    $repo: "owner/repo",
+    $pr: 1,
+    $type: "comment",
+    $subtype: "issue_comment",
+    $author: "testuser",
+    $body: "LGTM",
+    $created_at: "2025-01-15T00:00:00Z",
+    $captured_at: "2025-01-15T01:00:00Z",
+    $url: "https://github.com/owner/repo/pull/1#issuecomment-123",
+  });
+
+  // Verify retrieval
+  const entry = db
+    .query<
+      {
+        id: string;
+        type: string;
+        body: string;
+      },
+      []
+    >("SELECT id, type, body FROM entries WHERE id = 'comment-123'")
+    .get();
+
+  expect(entry?.id).toBe("comment-123");
+  expect(entry?.type).toBe("comment");
+  expect(entry?.body).toBe("LGTM");
+
+  closeDatabase(db);
+});
+
+test("sync_meta table has correct schema", () => {
+  const db = openDatabase();
+
+  // Insert sync metadata
+  db.prepare(`
+    INSERT INTO sync_meta (repo, cursor, last_sync, pr_count)
+    VALUES ($repo, $cursor, $last_sync, $pr_count)
+  `).run({
+    $repo: "owner/repo",
+    $cursor: "Y3Vyc29yOjEyMw==",
+    $last_sync: "2025-01-15T00:00:00Z",
+    $pr_count: 42,
+  });
+
+  // Verify retrieval
+  const meta = db
+    .query<
+      {
+        repo: string;
+        cursor: string;
+        pr_count: number;
+      },
+      []
+    >("SELECT repo, cursor, pr_count FROM sync_meta WHERE repo = 'owner/repo'")
+    .get();
+
+  expect(meta?.repo).toBe("owner/repo");
+  expect(meta?.cursor).toBe("Y3Vyc29yOjEyMw==");
+  expect(meta?.pr_count).toBe(42);
+
+  closeDatabase(db);
+});

--- a/packages/core/tests/repository.test.ts
+++ b/packages/core/tests/repository.test.ts
@@ -1,0 +1,891 @@
+import type { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { closeDatabase, openDatabase } from "../src/db";
+import {
+  clearRepo,
+  countEntries,
+  deleteEntriesByRepo,
+  deletePR,
+  deleteSyncMeta,
+  getAllSyncMeta,
+  getEntry,
+  getPR,
+  getPRsByState,
+  getRepos,
+  getSyncMeta,
+  insertEntries,
+  insertEntry,
+  queryEntries,
+  setSyncMeta,
+  updateEntry,
+  updatePRState,
+  upsertPR,
+  upsertPRs,
+  type EntryUpdates,
+  type PRMetadata,
+} from "../src/repository";
+import type { FirewatchEntry, SyncMetadata } from "../src/schema/entry";
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+function createTestPR(overrides: Partial<PRMetadata> = {}): PRMetadata {
+  return {
+    repo: "owner/repo",
+    number: 1,
+    state: "open",
+    isDraft: false,
+    title: "Test PR",
+    author: "testuser",
+    branch: "feature/test",
+    labels: ["bug", "enhancement"],
+    updatedAt: "2025-01-15T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function createTestEntry(
+  overrides: Partial<FirewatchEntry> = {}
+): FirewatchEntry {
+  return {
+    id: "entry-1",
+    repo: "owner/repo",
+    pr: 1,
+    pr_title: "Test PR",
+    pr_state: "open",
+    pr_author: "testuser",
+    pr_branch: "feature/test",
+    pr_labels: ["bug", "enhancement"],
+    type: "comment",
+    subtype: "issue_comment",
+    author: "commenter",
+    body: "LGTM",
+    created_at: "2025-01-15T00:00:00Z",
+    updated_at: "2025-01-15T01:00:00Z",
+    captured_at: "2025-01-15T02:00:00Z",
+    url: "https://github.com/owner/repo/pull/1#issuecomment-123",
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// PR Metadata Tests
+// =============================================================================
+
+describe("PR Metadata Operations", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = openDatabase();
+  });
+
+  test("upsertPR inserts a new PR", () => {
+    const pr = createTestPR();
+    upsertPR(db, pr);
+
+    const retrieved = getPR(db, pr.repo, pr.number);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved?.repo).toBe(pr.repo);
+    expect(retrieved?.number).toBe(pr.number);
+    expect(retrieved?.state).toBe(pr.state);
+    expect(retrieved?.isDraft).toBe(pr.isDraft);
+    expect(retrieved?.title).toBe(pr.title);
+    expect(retrieved?.author).toBe(pr.author);
+    expect(retrieved?.branch).toBe(pr.branch);
+    expect(retrieved?.labels).toEqual(pr.labels);
+    expect(retrieved?.updatedAt).toBe(pr.updatedAt);
+
+    closeDatabase(db);
+  });
+
+  test("upsertPR updates an existing PR", () => {
+    const pr = createTestPR();
+    upsertPR(db, pr);
+
+    // Update the PR
+    const updatedPR: PRMetadata = {
+      ...pr,
+      state: "merged",
+      title: "Updated Title",
+      labels: ["merged"],
+    };
+    upsertPR(db, updatedPR);
+
+    const retrieved = getPR(db, pr.repo, pr.number);
+    expect(retrieved?.state).toBe("merged");
+    expect(retrieved?.title).toBe("Updated Title");
+    expect(retrieved?.labels).toEqual(["merged"]);
+
+    closeDatabase(db);
+  });
+
+  test("upsertPRs inserts multiple PRs in transaction", () => {
+    const prs = [
+      createTestPR({ number: 1 }),
+      createTestPR({ number: 2, title: "Second PR" }),
+      createTestPR({ number: 3, title: "Third PR", state: "closed" }),
+    ];
+
+    upsertPRs(db, prs);
+
+    const pr1 = getPR(db, "owner/repo", 1);
+    const pr2 = getPR(db, "owner/repo", 2);
+    const pr3 = getPR(db, "owner/repo", 3);
+
+    expect(pr1?.number).toBe(1);
+    expect(pr2?.title).toBe("Second PR");
+    expect(pr3?.state).toBe("closed");
+
+    closeDatabase(db);
+  });
+
+  test("getPRsByState filters by open state", () => {
+    upsertPRs(db, [
+      createTestPR({ number: 1, state: "open", isDraft: false }),
+      createTestPR({ number: 2, state: "open", isDraft: true }),
+      createTestPR({ number: 3, state: "closed" }),
+      createTestPR({ number: 4, state: "merged" }),
+    ]);
+
+    const openPRs = getPRsByState(db, "owner/repo", ["open"]);
+    expect(openPRs).toHaveLength(1);
+    expect(openPRs[0]?.number).toBe(1);
+
+    closeDatabase(db);
+  });
+
+  test("getPRsByState filters by draft state", () => {
+    upsertPRs(db, [
+      createTestPR({ number: 1, state: "open", isDraft: false }),
+      createTestPR({ number: 2, state: "open", isDraft: true }),
+      createTestPR({ number: 3, state: "closed" }),
+    ]);
+
+    const draftPRs = getPRsByState(db, "owner/repo", ["draft"]);
+    expect(draftPRs).toHaveLength(1);
+    expect(draftPRs[0]?.number).toBe(2);
+    expect(draftPRs[0]?.isDraft).toBe(true);
+
+    closeDatabase(db);
+  });
+
+  test("getPRsByState filters by multiple states", () => {
+    upsertPRs(db, [
+      createTestPR({ number: 1, state: "open", isDraft: false }),
+      createTestPR({ number: 2, state: "open", isDraft: true }),
+      createTestPR({ number: 3, state: "closed" }),
+      createTestPR({ number: 4, state: "merged" }),
+    ]);
+
+    const prs = getPRsByState(db, "owner/repo", ["draft", "merged"]);
+    expect(prs).toHaveLength(2);
+    const numbers = prs.map((p) => p.number).toSorted();
+    expect(numbers).toEqual([2, 4]);
+
+    closeDatabase(db);
+  });
+
+  test("updatePRState updates state correctly", () => {
+    const pr = createTestPR({ state: "open", isDraft: false });
+    upsertPR(db, pr);
+
+    updatePRState(db, pr.repo, pr.number, "merged");
+
+    const retrieved = getPR(db, pr.repo, pr.number);
+    expect(retrieved?.state).toBe("merged");
+    expect(retrieved?.isDraft).toBe(false);
+
+    closeDatabase(db);
+  });
+
+  test("updatePRState handles draft state", () => {
+    const pr = createTestPR({ state: "open", isDraft: false });
+    upsertPR(db, pr);
+
+    updatePRState(db, pr.repo, pr.number, "draft");
+
+    const retrieved = getPR(db, pr.repo, pr.number);
+    expect(retrieved?.state).toBe("open");
+    expect(retrieved?.isDraft).toBe(true);
+
+    closeDatabase(db);
+  });
+
+  test("deletePR removes PR and its entries", () => {
+    const pr = createTestPR();
+    upsertPR(db, pr);
+    insertEntry(db, createTestEntry({ id: "e1", pr: pr.number }));
+
+    deletePR(db, pr.repo, pr.number);
+
+    expect(getPR(db, pr.repo, pr.number)).toBeNull();
+    expect(getEntry(db, "e1", pr.repo)).toBeNull();
+
+    closeDatabase(db);
+  });
+});
+
+// =============================================================================
+// Entry Operations Tests
+// =============================================================================
+
+describe("Entry Operations", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = openDatabase();
+    // Insert required PR for foreign key
+    upsertPR(db, createTestPR());
+  });
+
+  test("insertEntry inserts a new entry", () => {
+    const entry = createTestEntry();
+    insertEntry(db, entry);
+
+    const retrieved = getEntry(db, entry.id, entry.repo);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved?.id).toBe(entry.id);
+    expect(retrieved?.type).toBe(entry.type);
+    expect(retrieved?.body).toBe(entry.body);
+    expect(retrieved?.author).toBe(entry.author);
+
+    closeDatabase(db);
+  });
+
+  test("insertEntry handles JSON fields", () => {
+    const entry = createTestEntry({
+      id: "entry-graphite",
+      graphite: {
+        stack_id: "stack-123",
+        stack_position: 2,
+        stack_size: 5,
+        parent_pr: 10,
+      },
+      file_activity_after: {
+        modified: true,
+        commits_touching_file: 3,
+        latest_commit: "abc123",
+        latest_commit_at: "2025-01-15T00:00:00Z",
+      },
+      file_provenance: {
+        origin_pr: 5,
+        origin_branch: "main",
+        origin_commit: "def456",
+        stack_position: 1,
+      },
+    });
+
+    insertEntry(db, entry);
+
+    const retrieved = getEntry(db, entry.id, entry.repo);
+    expect(retrieved?.graphite).toEqual(entry.graphite);
+    expect(retrieved?.file_activity_after).toEqual(entry.file_activity_after);
+    expect(retrieved?.file_provenance).toEqual(entry.file_provenance);
+
+    closeDatabase(db);
+  });
+
+  test("insertEntry handles null JSON fields", () => {
+    const entry = createTestEntry({
+      id: "entry-no-json",
+      graphite: undefined,
+      file_activity_after: undefined,
+      file_provenance: undefined,
+    });
+
+    insertEntry(db, entry);
+
+    const retrieved = getEntry(db, entry.id, entry.repo);
+    expect(retrieved?.graphite).toBeUndefined();
+    expect(retrieved?.file_activity_after).toBeUndefined();
+    expect(retrieved?.file_provenance).toBeUndefined();
+
+    closeDatabase(db);
+  });
+
+  test("insertEntry replaces existing entry", () => {
+    const entry = createTestEntry({ body: "Original" });
+    insertEntry(db, entry);
+
+    const updated = { ...entry, body: "Updated" };
+    insertEntry(db, updated);
+
+    const retrieved = getEntry(db, entry.id, entry.repo);
+    expect(retrieved?.body).toBe("Updated");
+
+    closeDatabase(db);
+  });
+
+  test("insertEntries inserts multiple entries in transaction", () => {
+    upsertPR(db, createTestPR({ number: 2 }));
+
+    const entries = [
+      createTestEntry({ id: "e1", pr: 1 }),
+      createTestEntry({ id: "e2", pr: 1, type: "review" }),
+      createTestEntry({ id: "e3", pr: 2, author: "other" }),
+    ];
+
+    insertEntries(db, entries);
+
+    expect(getEntry(db, "e1", "owner/repo")).not.toBeNull();
+    expect(getEntry(db, "e2", "owner/repo")?.type).toBe("review");
+    expect(getEntry(db, "e3", "owner/repo")?.author).toBe("other");
+
+    closeDatabase(db);
+  });
+
+  test("insertEntries handles empty array", () => {
+    // Should not throw
+    insertEntries(db, []);
+    closeDatabase(db);
+  });
+
+  test("updateEntry updates specific fields", () => {
+    const entry = createTestEntry();
+    insertEntry(db, entry);
+
+    const updates: EntryUpdates = {
+      body: "Updated body",
+      state: "resolved",
+      file_activity_after: {
+        modified: true,
+        commits_touching_file: 5,
+      },
+    };
+
+    updateEntry(db, entry.id, entry.repo, updates);
+
+    const retrieved = getEntry(db, entry.id, entry.repo);
+    expect(retrieved?.body).toBe("Updated body");
+    expect(retrieved?.state).toBe("resolved");
+    expect(retrieved?.file_activity_after?.modified).toBe(true);
+    expect(retrieved?.file_activity_after?.commits_touching_file).toBe(5);
+
+    closeDatabase(db);
+  });
+
+  test("updateEntry handles empty updates", () => {
+    const entry = createTestEntry();
+    insertEntry(db, entry);
+
+    updateEntry(db, entry.id, entry.repo, {});
+
+    const retrieved = getEntry(db, entry.id, entry.repo);
+    expect(retrieved?.body).toBe(entry.body);
+
+    closeDatabase(db);
+  });
+
+  test("deleteEntriesByRepo removes all entries for repo", () => {
+    upsertPR(db, createTestPR({ repo: "other/repo" }));
+
+    insertEntries(db, [
+      createTestEntry({ id: "e1", repo: "owner/repo" }),
+      createTestEntry({ id: "e2", repo: "owner/repo" }),
+      createTestEntry({ id: "e3", repo: "other/repo" }),
+    ]);
+
+    deleteEntriesByRepo(db, "owner/repo");
+
+    expect(getEntry(db, "e1", "owner/repo")).toBeNull();
+    expect(getEntry(db, "e2", "owner/repo")).toBeNull();
+    expect(getEntry(db, "e3", "other/repo")).not.toBeNull();
+
+    closeDatabase(db);
+  });
+});
+
+// =============================================================================
+// Query Tests
+// =============================================================================
+
+describe("Query Operations", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = openDatabase();
+
+    // Setup test data
+    upsertPRs(db, [
+      createTestPR({
+        number: 1,
+        state: "open",
+        isDraft: false,
+        labels: ["bug"],
+      }),
+      createTestPR({
+        number: 2,
+        state: "open",
+        isDraft: true,
+        labels: ["feature"],
+      }),
+      createTestPR({ number: 3, state: "closed", labels: ["docs"] }),
+      createTestPR({ number: 4, state: "merged", labels: ["bug", "urgent"] }),
+    ]);
+
+    insertEntries(db, [
+      createTestEntry({
+        id: "e1",
+        pr: 1,
+        type: "comment",
+        author: "alice",
+        created_at: "2025-01-10T00:00:00Z",
+      }),
+      createTestEntry({
+        id: "e2",
+        pr: 1,
+        type: "review",
+        author: "bob",
+        created_at: "2025-01-11T00:00:00Z",
+      }),
+      createTestEntry({
+        id: "e3",
+        pr: 2,
+        type: "comment",
+        author: "alice",
+        created_at: "2025-01-12T00:00:00Z",
+      }),
+      createTestEntry({
+        id: "e4",
+        pr: 3,
+        type: "commit",
+        author: "carol",
+        created_at: "2025-01-13T00:00:00Z",
+      }),
+      createTestEntry({
+        id: "e5",
+        pr: 4,
+        type: "ci",
+        author: "github-actions",
+        created_at: "2025-01-14T00:00:00Z",
+      }),
+    ]);
+  });
+
+  test("queryEntries returns all entries when no filters", () => {
+    const results = queryEntries(db);
+    expect(results).toHaveLength(5);
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries orders by created_at descending", () => {
+    const results = queryEntries(db);
+    expect(results[0]?.id).toBe("e5");
+    expect(results[4]?.id).toBe("e1");
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries filters by id", () => {
+    const results = queryEntries(db, { id: "e2" });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.id).toBe("e2");
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries filters by repo substring", () => {
+    upsertPR(db, createTestPR({ repo: "other/project", number: 99 }));
+    insertEntry(
+      db,
+      createTestEntry({ id: "other-e1", repo: "other/project", pr: 99 })
+    );
+
+    const results = queryEntries(db, { repo: "owner" });
+    expect(results).toHaveLength(5);
+    expect(results.every((e) => e.repo === "owner/repo")).toBe(true);
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries filters by pr number", () => {
+    const results = queryEntries(db, { pr: 1 });
+    expect(results).toHaveLength(2);
+    expect(results.every((e) => e.pr === 1)).toBe(true);
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries filters by multiple pr numbers", () => {
+    const results = queryEntries(db, { prs: [1, 3] });
+    expect(results).toHaveLength(3);
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries filters by author", () => {
+    const results = queryEntries(db, { author: "alice" });
+    expect(results).toHaveLength(2);
+    expect(results.every((e) => e.author === "alice")).toBe(true);
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries filters by single type", () => {
+    const results = queryEntries(db, { type: "comment" });
+    expect(results).toHaveLength(2);
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries filters by multiple types", () => {
+    const results = queryEntries(db, { type: ["comment", "review"] });
+    expect(results).toHaveLength(3);
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries filters by open state (excludes drafts)", () => {
+    const results = queryEntries(db, { states: ["open"] });
+    expect(results).toHaveLength(2);
+    expect(results.every((e) => e.pr_state === "open")).toBe(true);
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries filters by draft state", () => {
+    const results = queryEntries(db, { states: ["draft"] });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.pr_state).toBe("draft");
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries filters by multiple states", () => {
+    const results = queryEntries(db, { states: ["open", "merged"] });
+    expect(results).toHaveLength(3);
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries filters by label", () => {
+    const results = queryEntries(db, { label: "bug" });
+    expect(results).toHaveLength(3); // PR 1 and PR 4 have "bug" label
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries label filter is case-insensitive", () => {
+    const results = queryEntries(db, { label: "BUG" });
+    expect(results).toHaveLength(3);
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries filters by since date", () => {
+    const results = queryEntries(db, {
+      since: new Date("2025-01-12T00:00:00Z"),
+    });
+    expect(results).toHaveLength(3);
+    expect(results.map((e) => e.id).toSorted()).toEqual(["e3", "e4", "e5"]);
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries combines multiple filters", () => {
+    const results = queryEntries(db, {
+      type: "comment",
+      states: ["open", "draft"],
+    });
+    expect(results).toHaveLength(2);
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries derives pr_state from PR table", () => {
+    // Initially PR 1 is open
+    let results = queryEntries(db, { pr: 1 });
+    expect(results[0]?.pr_state).toBe("open");
+
+    // Update PR state to merged
+    updatePRState(db, "owner/repo", 1, "merged");
+
+    // Now entries should reflect the new state
+    results = queryEntries(db, { pr: 1 });
+    expect(results[0]?.pr_state).toBe("merged");
+
+    closeDatabase(db);
+  });
+
+  test("countEntries counts matching entries", () => {
+    expect(countEntries(db)).toBe(5);
+    expect(countEntries(db, { type: "comment" })).toBe(2);
+    expect(countEntries(db, { states: ["draft"] })).toBe(1);
+
+    closeDatabase(db);
+  });
+
+  test("getRepos returns distinct repos", () => {
+    upsertPR(db, createTestPR({ repo: "other/project", number: 99 }));
+    insertEntry(
+      db,
+      createTestEntry({ id: "other-e1", repo: "other/project", pr: 99 })
+    );
+
+    const repos = getRepos(db);
+    expect(repos).toHaveLength(2);
+    expect(repos).toContain("owner/repo");
+    expect(repos).toContain("other/project");
+
+    closeDatabase(db);
+  });
+});
+
+// =============================================================================
+// Sync Metadata Tests
+// =============================================================================
+
+describe("Sync Metadata Operations", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = openDatabase();
+  });
+
+  test("setSyncMeta inserts new metadata", () => {
+    const meta: SyncMetadata = {
+      repo: "owner/repo",
+      cursor: "Y3Vyc29yOjEyMw==",
+      last_sync: "2025-01-15T00:00:00Z",
+      pr_count: 42,
+    };
+
+    setSyncMeta(db, meta);
+
+    const retrieved = getSyncMeta(db, meta.repo);
+    expect(retrieved).toEqual(meta);
+
+    closeDatabase(db);
+  });
+
+  test("setSyncMeta updates existing metadata", () => {
+    const meta: SyncMetadata = {
+      repo: "owner/repo",
+      cursor: "cursor-1",
+      last_sync: "2025-01-15T00:00:00Z",
+      pr_count: 10,
+    };
+
+    setSyncMeta(db, meta);
+
+    const updated: SyncMetadata = {
+      ...meta,
+      cursor: "cursor-2",
+      last_sync: "2025-01-16T00:00:00Z",
+      pr_count: 20,
+    };
+
+    setSyncMeta(db, updated);
+
+    const retrieved = getSyncMeta(db, meta.repo);
+    expect(retrieved?.cursor).toBe("cursor-2");
+    expect(retrieved?.pr_count).toBe(20);
+
+    closeDatabase(db);
+  });
+
+  test("getSyncMeta returns null for non-existent repo", () => {
+    const result = getSyncMeta(db, "nonexistent/repo");
+    expect(result).toBeNull();
+
+    closeDatabase(db);
+  });
+
+  test("setSyncMeta handles null cursor", () => {
+    const meta: SyncMetadata = {
+      repo: "owner/repo",
+      cursor: undefined,
+      last_sync: "2025-01-15T00:00:00Z",
+      pr_count: 0,
+    };
+
+    setSyncMeta(db, meta);
+
+    const retrieved = getSyncMeta(db, meta.repo);
+    expect(retrieved?.cursor).toBeUndefined();
+
+    closeDatabase(db);
+  });
+
+  test("deleteSyncMeta removes metadata", () => {
+    const meta: SyncMetadata = {
+      repo: "owner/repo",
+      cursor: "cursor",
+      last_sync: "2025-01-15T00:00:00Z",
+      pr_count: 10,
+    };
+
+    setSyncMeta(db, meta);
+    expect(getSyncMeta(db, meta.repo)).not.toBeNull();
+
+    deleteSyncMeta(db, meta.repo);
+    expect(getSyncMeta(db, meta.repo)).toBeNull();
+
+    closeDatabase(db);
+  });
+
+  test("getAllSyncMeta returns all metadata", () => {
+    setSyncMeta(db, {
+      repo: "owner/repo1",
+      cursor: "c1",
+      last_sync: "2025-01-15T00:00:00Z",
+      pr_count: 10,
+    });
+    setSyncMeta(db, {
+      repo: "owner/repo2",
+      cursor: "c2",
+      last_sync: "2025-01-16T00:00:00Z",
+      pr_count: 20,
+    });
+
+    const all = getAllSyncMeta(db);
+    expect(all).toHaveLength(2);
+    expect(all.map((m) => m.repo).toSorted()).toEqual([
+      "owner/repo1",
+      "owner/repo2",
+    ]);
+
+    closeDatabase(db);
+  });
+});
+
+// =============================================================================
+// Utility Operations Tests
+// =============================================================================
+
+describe("Utility Operations", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = openDatabase();
+  });
+
+  test("clearRepo removes all data for a repo", () => {
+    upsertPR(db, createTestPR({ repo: "owner/repo", number: 1 }));
+    upsertPR(db, createTestPR({ repo: "other/repo", number: 2 }));
+
+    insertEntry(db, createTestEntry({ id: "e1", repo: "owner/repo", pr: 1 }));
+    insertEntry(db, createTestEntry({ id: "e2", repo: "other/repo", pr: 2 }));
+
+    setSyncMeta(db, {
+      repo: "owner/repo",
+      last_sync: "2025-01-15T00:00:00Z",
+      pr_count: 1,
+    });
+    setSyncMeta(db, {
+      repo: "other/repo",
+      last_sync: "2025-01-15T00:00:00Z",
+      pr_count: 1,
+    });
+
+    clearRepo(db, "owner/repo");
+
+    // owner/repo should be cleared
+    expect(getEntry(db, "e1", "owner/repo")).toBeNull();
+    expect(getPR(db, "owner/repo", 1)).toBeNull();
+    expect(getSyncMeta(db, "owner/repo")).toBeNull();
+
+    // other/repo should remain
+    expect(getEntry(db, "e2", "other/repo")).not.toBeNull();
+    expect(getPR(db, "other/repo", 2)).not.toBeNull();
+    expect(getSyncMeta(db, "other/repo")).not.toBeNull();
+
+    closeDatabase(db);
+  });
+});
+
+// =============================================================================
+// rowToEntry Tests
+// =============================================================================
+
+describe("rowToEntry conversion", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = openDatabase();
+  });
+
+  test("rowToEntry derives pr_state correctly for open PR", () => {
+    upsertPR(db, createTestPR({ state: "open", isDraft: false }));
+    insertEntry(db, createTestEntry({ id: "e1" }));
+
+    const entry = getEntry(db, "e1", "owner/repo");
+    expect(entry?.pr_state).toBe("open");
+
+    closeDatabase(db);
+  });
+
+  test("rowToEntry derives pr_state correctly for draft PR", () => {
+    upsertPR(db, createTestPR({ state: "open", isDraft: true }));
+    insertEntry(db, createTestEntry({ id: "e1" }));
+
+    const entry = getEntry(db, "e1", "owner/repo");
+    expect(entry?.pr_state).toBe("draft");
+
+    closeDatabase(db);
+  });
+
+  test("rowToEntry derives pr_state correctly for merged PR", () => {
+    upsertPR(db, createTestPR({ state: "merged", isDraft: false }));
+    insertEntry(db, createTestEntry({ id: "e1" }));
+
+    const entry = getEntry(db, "e1", "owner/repo");
+    expect(entry?.pr_state).toBe("merged");
+
+    closeDatabase(db);
+  });
+
+  test("rowToEntry handles missing PR fields gracefully", () => {
+    upsertPR(db, {
+      repo: "owner/repo",
+      number: 1,
+      state: "open",
+      isDraft: false,
+      labels: [],
+      // No title, author, branch
+    });
+    insertEntry(db, createTestEntry({ id: "e1" }));
+
+    const entry = getEntry(db, "e1", "owner/repo");
+    expect(entry?.pr_title).toBe("");
+    expect(entry?.pr_author).toBe("unknown");
+    expect(entry?.pr_branch).toBe("");
+    expect(entry?.pr_labels).toBeUndefined();
+
+    closeDatabase(db);
+  });
+
+  test("rowToEntry handles empty labels array", () => {
+    upsertPR(db, createTestPR({ labels: [] }));
+    insertEntry(db, createTestEntry({ id: "e1" }));
+
+    const entry = getEntry(db, "e1", "owner/repo");
+    expect(entry?.pr_labels).toBeUndefined();
+
+    closeDatabase(db);
+  });
+
+  test("rowToEntry reflects PR state changes", () => {
+    upsertPR(db, createTestPR({ state: "open", isDraft: false }));
+    insertEntry(db, createTestEntry({ id: "e1" }));
+
+    // Initial state
+    let entry = getEntry(db, "e1", "owner/repo");
+    expect(entry?.pr_state).toBe("open");
+
+    // Simulate PR becoming draft
+    updatePRState(db, "owner/repo", 1, "draft");
+    entry = getEntry(db, "e1", "owner/repo");
+    expect(entry?.pr_state).toBe("draft");
+
+    // Simulate PR being merged
+    updatePRState(db, "owner/repo", 1, "merged");
+    entry = getEntry(db, "e1", "owner/repo");
+    expect(entry?.pr_state).toBe("merged");
+
+    closeDatabase(db);
+  });
+});


### PR DESCRIPTION
Add SQLite storage foundation for Firewatch, replacing JSONL files.

New modules:
- db.ts: Database connection, schema creation, migrations
- repository.ts: Type-safe CRUD operations for entries, PRs, sync metadata

Key design decisions:
- Separate tables for mutable PR metadata and immutable activity entries
- WAL mode for concurrent read/write performance
- Prepared statement caching for efficiency
- JSON columns for complex nested data (graphite, file_activity)

Schema:
- prs: Mutable PR state (updated on each sync)
- entries: Immutable activity log
- sync_meta: Per-repo sync cursors

This is the foundation for fixing issue #37 (stale PR states).

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>