### PR TITLE
fix(core): use SQLite for sync/query/check with live PR state

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,16 +24,50 @@ export { detectAuth, type AuthResult, type AuthSource } from "./auth";
 
 // Cache
 export {
-  appendJsonl,
-  deduplicateEntries,
+  closeFirewatchDb,
   ensureDirectories,
+  getDatabase,
   getRepoCachePath,
   parseRepoCacheFilename,
   PATHS,
-  readEntriesJsonl,
   readJsonl,
-  writeJsonl,
 } from "./cache";
+
+// Database
+export {
+  closeDatabase,
+  CURRENT_SCHEMA_VERSION,
+  getSchemaVersion,
+  initSchema,
+  migrateSchema,
+  openDatabase,
+} from "./db";
+
+// Repository
+export {
+  clearRepo,
+  countEntries,
+  deleteEntriesByRepo,
+  deletePR,
+  deleteSyncMeta,
+  getAllSyncMeta,
+  getEntry,
+  getPR,
+  getPRsByState,
+  getRepos,
+  getSyncMeta,
+  insertEntries,
+  insertEntry,
+  queryEntries as queryEntriesDb,
+  rowToEntry,
+  setSyncMeta,
+  updateEntry,
+  updatePRState,
+  upsertPR,
+  upsertPRs,
+  type EntryUpdates,
+  type PRMetadata,
+} from "./repository";
 
 // GitHub
 export {
@@ -56,7 +90,12 @@ export {
 } from "./query";
 
 // Check
-export { checkRepo, type CheckOptions, type CheckResult } from "./check";
+export {
+  checkRepo,
+  checkRepoDb,
+  type CheckOptions,
+  type CheckResult,
+} from "./check";
 
 // Worklist
 export { buildWorklist, sortWorklist } from "./worklist";

--- a/packages/core/src/repository.ts
+++ b/packages/core/src/repository.ts
@@ -447,7 +447,10 @@ function buildWhereClause(filters: QueryFilters): {
     params.$id = filters.id;
   }
 
-  if (filters.repo) {
+  if (filters.exactRepo) {
+    conditions.push("e.repo = $exactRepo");
+    params.$exactRepo = filters.exactRepo;
+  } else if (filters.repo) {
     conditions.push("e.repo LIKE $repo");
     params.$repo = `%${filters.repo}%`;
   }

--- a/packages/core/tests/check.test.ts
+++ b/packages/core/tests/check.test.ts
@@ -1,19 +1,29 @@
-import { afterAll, expect, test } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { closeDatabase, openDatabase } from "../src/db";
+import {
+  getEntry,
+  insertEntries,
+  queryEntries,
+  upsertPR,
+  type PRMetadata,
+} from "../src/repository";
 import type { FirewatchEntry } from "../src/schema/entry";
 
 const tempRoot = await mkdtemp(join(tmpdir(), "firewatch-check-"));
 
-const { ensureDirectories, getRepoCachePath, readJsonl, writeJsonl, PATHS } =
+const { closeFirewatchDb, ensureDirectories, getDatabase, PATHS } =
   await import("../src/cache");
-const { checkRepo } = await import("../src/check");
+const { checkRepo, checkRepoDb } = await import("../src/check");
 
 const originalPaths = { ...PATHS };
 
 afterAll(async () => {
+  closeFirewatchDb();
   Object.assign(PATHS as Record<string, string>, originalPaths);
   await rm(tempRoot, { recursive: true, force: true });
 });
@@ -24,13 +34,31 @@ Object.assign(PATHS as Record<string, string>, {
   data: join(tempRoot, "data"),
   repos: join(tempRoot, "cache", "repos"),
   meta: join(tempRoot, "cache", "meta.jsonl"),
+  db: join(tempRoot, "cache", "firewatch.db"),
   configFile: join(tempRoot, "config", "config.toml"),
 });
 
 await ensureDirectories();
 
+function createTestPRForLegacy(
+  overrides: Partial<PRMetadata> = {}
+): PRMetadata {
+  return {
+    repo: "outfitter-dev/firewatch",
+    number: 42,
+    state: "open",
+    isDraft: false,
+    title: "Add check",
+    author: "alice",
+    branch: "feat/check",
+    labels: [],
+    ...overrides,
+  };
+}
+
 test("checkRepo updates file_activity_after for comments", async () => {
   const repo = "outfitter-dev/firewatch";
+  const db = getDatabase();
   const entries: FirewatchEntry[] = [
     {
       id: "comment-1",
@@ -78,15 +106,15 @@ test("checkRepo updates file_activity_after for comments", async () => {
     },
   ];
 
-  await writeJsonl(getRepoCachePath(repo), entries);
+  upsertPR(db, createTestPRForLegacy());
+  insertEntries(db, entries);
 
   const result = await checkRepo(repo);
   expect(result.comments_checked).toBe(2);
   expect(result.entries_updated).toBe(2);
 
-  const updated = await readJsonl<FirewatchEntry>(getRepoCachePath(repo));
-  const firstComment = updated.find((entry) => entry.id === "comment-1");
-  const secondComment = updated.find((entry) => entry.id === "comment-2");
+  const firstComment = getEntry(db, "comment-1", repo);
+  const secondComment = getEntry(db, "comment-2", repo);
 
   expect(firstComment?.file_activity_after?.modified).toBe(true);
   expect(firstComment?.file_activity_after?.commits_touching_file).toBe(1);
@@ -100,10 +128,11 @@ test("checkRepo updates file_activity_after for comments", async () => {
 });
 
 test("checkRepo uses file matches when commit files are available", async () => {
-  const repo = "outfitter-dev/firewatch";
+  const repo = "outfitter-dev/firewatch-file-matches";
+  const db = getDatabase();
   const entries: FirewatchEntry[] = [
     {
-      id: "comment-1",
+      id: "comment-file-1",
       repo,
       pr: 99,
       pr_title: "Add provenance",
@@ -119,7 +148,7 @@ test("checkRepo uses file matches when commit files are available", async () => 
       captured_at: "2025-01-02T00:00:00.000Z",
     },
     {
-      id: "commit-1",
+      id: "commit-file-1",
       repo,
       pr: 99,
       pr_title: "Add provenance",
@@ -133,7 +162,7 @@ test("checkRepo uses file matches when commit files are available", async () => 
       captured_at: "2025-01-02T12:01:00.000Z",
     },
     {
-      id: "commit-2",
+      id: "commit-file-2",
       repo,
       pr: 99,
       pr_title: "Add provenance",
@@ -148,11 +177,12 @@ test("checkRepo uses file matches when commit files are available", async () => 
     },
   ];
 
-  await writeJsonl(getRepoCachePath(repo), entries);
+  upsertPR(db, createTestPRForLegacy({ repo, number: 99 }));
+  insertEntries(db, entries);
 
   const filesByCommit = new Map<string, string[]>([
-    ["commit-1", ["src/other.ts"]],
-    ["commit-2", ["src/target.ts"]],
+    ["commit-file-1", ["src/other.ts"]],
+    ["commit-file-2", ["src/target.ts"]],
   ]);
   const result = await checkRepo(repo, {
     resolveCommitFiles: (commitId: string) =>
@@ -161,18 +191,18 @@ test("checkRepo uses file matches when commit files are available", async () => 
 
   expect(result.comments_checked).toBe(1);
 
-  const updated = await readJsonl<FirewatchEntry>(getRepoCachePath(repo));
-  const comment = updated.find((entry) => entry.id === "comment-1");
+  const comment = getEntry(db, "comment-file-1", repo);
   expect(comment?.file_activity_after?.modified).toBe(true);
   expect(comment?.file_activity_after?.commits_touching_file).toBe(1);
-  expect(comment?.file_activity_after?.latest_commit).toBe("commit-2");
+  expect(comment?.file_activity_after?.latest_commit).toBe("commit-file-2");
 });
 
 test("checkRepo falls back to all commits when file lists are partial", async () => {
-  const repo = "outfitter-dev/firewatch";
+  const repo = "outfitter-dev/firewatch-partial";
+  const db = getDatabase();
   const entries: FirewatchEntry[] = [
     {
-      id: "comment-1",
+      id: "comment-partial-1",
       repo,
       pr: 101,
       pr_title: "Add provenance",
@@ -188,7 +218,7 @@ test("checkRepo falls back to all commits when file lists are partial", async ()
       captured_at: "2025-01-02T00:00:00.000Z",
     },
     {
-      id: "commit-1",
+      id: "commit-partial-1",
       repo,
       pr: 101,
       pr_title: "Add provenance",
@@ -202,7 +232,7 @@ test("checkRepo falls back to all commits when file lists are partial", async ()
       captured_at: "2025-01-02T12:01:00.000Z",
     },
     {
-      id: "commit-2",
+      id: "commit-partial-2",
       repo,
       pr: 101,
       pr_title: "Add provenance",
@@ -217,21 +247,228 @@ test("checkRepo falls back to all commits when file lists are partial", async ()
     },
   ];
 
-  await writeJsonl(getRepoCachePath(repo), entries);
+  upsertPR(db, createTestPRForLegacy({ repo, number: 101 }));
+  insertEntries(db, entries);
 
   const filesByCommit = new Map<string, string[] | null>([
-    ["commit-1", ["src/other.ts"]],
-    ["commit-2", null],
+    ["commit-partial-1", ["src/other.ts"]],
+    ["commit-partial-2", null],
   ]);
   await checkRepo(repo, {
     resolveCommitFiles: (commitId: string) =>
       Promise.resolve(filesByCommit.get(commitId) as string[] | null),
   });
 
-  const updated = await readJsonl<FirewatchEntry>(getRepoCachePath(repo));
-  const comment = updated.find((entry) => entry.id === "comment-1");
+  const comment = getEntry(db, "comment-partial-1", repo);
   expect(comment?.file_activity_after?.modified).toBe(true);
   // When file data is partial (commit-2 returns null), falls back to counting all commits
   expect(comment?.file_activity_after?.commits_touching_file).toBe(2);
-  expect(comment?.file_activity_after?.latest_commit).toBe("commit-2");
+  expect(comment?.file_activity_after?.latest_commit).toBe("commit-partial-2");
+});
+
+// =============================================================================
+// SQLite-based Check Tests (checkRepoDb)
+// =============================================================================
+
+function createTestPR(overrides: Partial<PRMetadata> = {}): PRMetadata {
+  return {
+    repo: "outfitter-dev/firewatch",
+    number: 42,
+    state: "open",
+    isDraft: false,
+    title: "Add check",
+    author: "alice",
+    branch: "feat/check",
+    labels: [],
+    ...overrides,
+  };
+}
+
+function createTestEntry(
+  overrides: Partial<FirewatchEntry> = {}
+): FirewatchEntry {
+  return {
+    id: "entry-1",
+    repo: "outfitter-dev/firewatch",
+    pr: 42,
+    pr_title: "Add check",
+    pr_state: "open",
+    pr_author: "alice",
+    pr_branch: "feat/check",
+    type: "comment",
+    subtype: "review_comment",
+    author: "bob",
+    body: "Needs work",
+    created_at: "2025-01-01T00:00:00.000Z",
+    captured_at: "2025-01-02T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/**
+ * Helper to create a file resolver from a Map.
+ * Extracted outside tests to avoid linter warnings about conditionals in tests.
+ */
+function createFileResolver(
+  filesByCommit: Map<string, string[]>
+): (commitId: string) => Promise<string[] | null> {
+  return (commitId: string) => {
+    const files = filesByCommit.get(commitId);
+    return Promise.resolve(files === undefined ? null : files);
+  };
+}
+
+describe("checkRepoDb - SQLite-based check", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = openDatabase();
+  });
+
+  test("checkRepoDb updates file_activity_after for comments in SQLite", async () => {
+    // Setup: Insert PR and entries into SQLite
+    upsertPR(db, createTestPR());
+    insertEntries(db, [
+      createTestEntry({
+        id: "comment-1",
+        type: "comment",
+        created_at: "2025-01-01T00:00:00.000Z",
+      }),
+      createTestEntry({
+        id: "commit-1",
+        type: "commit",
+        author: "alice",
+        body: "Fix comment",
+        created_at: "2025-01-02T12:00:00.000Z",
+      }),
+      createTestEntry({
+        id: "comment-2",
+        type: "comment",
+        body: "Another note",
+        created_at: "2025-01-03T00:00:00.000Z",
+      }),
+    ]);
+
+    // Execute check
+    const result = await checkRepoDb(db, "outfitter-dev/firewatch");
+
+    // Verify result counts
+    expect(result.comments_checked).toBe(2);
+    expect(result.entries_updated).toBe(2);
+
+    // Verify entries are updated in SQLite
+    const firstComment = getEntry(db, "comment-1", "outfitter-dev/firewatch");
+    const secondComment = getEntry(db, "comment-2", "outfitter-dev/firewatch");
+
+    expect(firstComment?.file_activity_after?.modified).toBe(true);
+    expect(firstComment?.file_activity_after?.commits_touching_file).toBe(1);
+    expect(firstComment?.file_activity_after?.latest_commit).toBe("commit-1");
+    expect(firstComment?.file_activity_after?.latest_commit_at).toBe(
+      "2025-01-02T12:00:00.000Z"
+    );
+
+    // Comment after the commit should show no modifications
+    expect(secondComment?.file_activity_after?.modified).toBe(false);
+    expect(secondComment?.file_activity_after?.commits_touching_file).toBe(0);
+
+    closeDatabase(db);
+  });
+
+  test("checkRepoDb uses file matches when commit files are available", async () => {
+    upsertPR(db, createTestPR({ number: 99 }));
+    insertEntries(db, [
+      createTestEntry({
+        id: "comment-1",
+        pr: 99,
+        file: "src/target.ts",
+        created_at: "2025-01-01T00:00:00.000Z",
+      }),
+      createTestEntry({
+        id: "commit-1",
+        pr: 99,
+        type: "commit",
+        body: "Other file",
+        created_at: "2025-01-02T12:00:00.000Z",
+      }),
+      createTestEntry({
+        id: "commit-2",
+        pr: 99,
+        type: "commit",
+        body: "Target file",
+        created_at: "2025-01-03T12:00:00.000Z",
+      }),
+    ]);
+
+    const filesByCommit = new Map<string, string[]>([
+      ["commit-1", ["src/other.ts"]],
+      ["commit-2", ["src/target.ts"]],
+    ]);
+
+    const result = await checkRepoDb(db, "outfitter-dev/firewatch", {
+      resolveCommitFiles: createFileResolver(filesByCommit),
+    });
+
+    expect(result.comments_checked).toBe(1);
+
+    const comment = getEntry(db, "comment-1", "outfitter-dev/firewatch");
+    expect(comment?.file_activity_after?.modified).toBe(true);
+    // Only commit-2 touches the target file
+    expect(comment?.file_activity_after?.commits_touching_file).toBe(1);
+    expect(comment?.file_activity_after?.latest_commit).toBe("commit-2");
+
+    closeDatabase(db);
+  });
+
+  test("checkRepoDb returns empty result when no entries", async () => {
+    const result = await checkRepoDb(db, "nonexistent/repo");
+
+    expect(result.repo).toBe("nonexistent/repo");
+    expect(result.comments_checked).toBe(0);
+    expect(result.entries_updated).toBe(0);
+
+    closeDatabase(db);
+  });
+
+  test("checkRepoDb skips already up-to-date entries", async () => {
+    upsertPR(db, createTestPR());
+    insertEntries(db, [
+      createTestEntry({
+        id: "comment-1",
+        type: "comment",
+        created_at: "2025-01-01T00:00:00.000Z",
+        // Already has correct file_activity_after
+        file_activity_after: {
+          modified: false,
+          commits_touching_file: 0,
+        },
+      }),
+    ]);
+
+    const result = await checkRepoDb(db, "outfitter-dev/firewatch");
+
+    expect(result.comments_checked).toBe(1);
+    // No updates needed since data is already correct
+    expect(result.entries_updated).toBe(0);
+
+    closeDatabase(db);
+  });
+
+  test("checkRepoDb reflects current PR state from database", () => {
+    // Create PR as open
+    upsertPR(db, createTestPR({ state: "open" }));
+    insertEntries(db, [createTestEntry({ id: "comment-1", type: "comment" })]);
+
+    // Verify initial state
+    let entries = queryEntries(db, { repo: "outfitter-dev/firewatch" });
+    expect(entries[0]?.pr_state).toBe("open");
+
+    // Update PR state to merged (simulating what sync would do)
+    upsertPR(db, createTestPR({ state: "merged" }));
+
+    // Verify entries now reflect merged state
+    entries = queryEntries(db, { repo: "outfitter-dev/firewatch" });
+    expect(entries[0]?.pr_state).toBe("merged");
+
+    closeDatabase(db);
+  });
 });

--- a/packages/core/tests/query.test.ts
+++ b/packages/core/tests/query.test.ts
@@ -1,19 +1,32 @@
-import { afterAll, expect, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import type { PRMetadata } from "../src/repository";
 import type { FirewatchEntry } from "../src/schema/entry";
 
 const tempRoot = await mkdtemp(join(tmpdir(), "firewatch-query-"));
 
-const { ensureDirectories, getRepoCachePath, writeJsonl, PATHS } =
+const { closeFirewatchDb, ensureDirectories, getDatabase, PATHS } =
   await import("../src/cache");
 const { queryEntries } = await import("../src/query");
+const {
+  insertEntries,
+  setSyncMeta,
+  updatePRState,
+  upsertPRs,
+  clearRepo,
+} = await import("../src/repository");
+
+// Close any existing db connection before setting up test paths
+// This is needed because the db singleton might be pointing to a different path
+closeFirewatchDb();
 
 const originalPaths = { ...PATHS };
 
 afterAll(async () => {
+  closeFirewatchDb();
   Object.assign(PATHS as Record<string, string>, originalPaths);
   await rm(tempRoot, { recursive: true, force: true });
 });
@@ -24,6 +37,7 @@ Object.assign(PATHS as Record<string, string>, {
   data: join(tempRoot, "data"),
   repos: join(tempRoot, "cache", "repos"),
   meta: join(tempRoot, "cache", "meta.jsonl"),
+  db: join(tempRoot, "cache", "firewatch.db"),
   configFile: join(tempRoot, "config", "config.toml"),
 });
 
@@ -87,8 +101,43 @@ const entriesB: FirewatchEntry[] = [
   },
 ];
 
-await writeJsonl(getRepoCachePath(repoA), entriesA);
-await writeJsonl(getRepoCachePath(repoB), entriesB);
+// Set up test data in SQLite
+const db = getDatabase();
+upsertPRs(db, [
+  {
+    repo: repoA,
+    number: 1,
+    state: "open",
+    isDraft: false,
+    title: "Fix auth flow",
+    author: "alice",
+    branch: "main",
+    labels: ["bug", "ui"],
+  },
+  {
+    repo: repoA,
+    number: 2,
+    state: "open",
+    isDraft: true,
+    title: "Add caching",
+    author: "bob",
+    branch: "cache",
+    labels: ["infra"],
+  },
+  {
+    repo: repoB,
+    number: 5,
+    state: "closed",
+    isDraft: false,
+    title: "Refactor core",
+    author: "dana",
+    branch: "refactor",
+    labels: [],
+  },
+]);
+insertEntries(db, [...entriesA, ...entriesB]);
+setSyncMeta(db, { repo: repoA, last_sync: "2025-01-15T00:00:00Z", pr_count: 2 });
+setSyncMeta(db, { repo: repoB, last_sync: "2025-01-15T00:00:00Z", pr_count: 1 });
 
 test("queryEntries filters by repo substring", async () => {
   const results = await queryEntries({ filters: { repo: "firewatch" } });
@@ -130,4 +179,216 @@ test("queryEntries applies limit and offset", async () => {
   const results = await queryEntries({ offset: 1, limit: 1 });
   expect(results).toHaveLength(1);
   expect(results[0]?.id).toBe("review-1");
+});
+
+// =============================================================================
+// SQLite Path Tests (Issue #37 fix)
+// =============================================================================
+
+describe("SQLite query path", () => {
+  const sqliteRepo = "sqlite/test-repo";
+
+  function createTestPR(overrides: Partial<PRMetadata> = {}): PRMetadata {
+    return {
+      repo: sqliteRepo,
+      number: 1,
+      state: "open",
+      isDraft: false,
+      title: "Test PR",
+      author: "testuser",
+      branch: "feature/test",
+      labels: ["bug"],
+      updatedAt: "2025-01-15T00:00:00Z",
+      ...overrides,
+    };
+  }
+
+  function createTestEntry(
+    overrides: Partial<FirewatchEntry> = {}
+  ): FirewatchEntry {
+    return {
+      id: "sqlite-entry-1",
+      repo: sqliteRepo,
+      pr: 1,
+      pr_title: "Test PR",
+      pr_state: "open",
+      pr_author: "testuser",
+      pr_branch: "feature/test",
+      pr_labels: ["bug"],
+      type: "comment",
+      author: "commenter",
+      body: "Test comment",
+      created_at: "2025-01-15T00:00:00Z",
+      captured_at: "2025-01-15T02:00:00Z",
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    // Clear SQLite data for the test repo
+    const db = getDatabase();
+    clearRepo(db, sqliteRepo);
+  });
+
+  test("uses SQLite when data exists", async () => {
+    const db = getDatabase();
+
+    // Set up SQLite data
+    upsertPRs(db, [createTestPR({ number: 1, state: "open" })]);
+    insertEntries(db, [createTestEntry({ id: "e1", pr: 1 })]);
+    setSyncMeta(db, {
+      repo: sqliteRepo,
+      last_sync: "2025-01-15T00:00:00Z",
+      pr_count: 1,
+    });
+
+    const results = await queryEntries({ filters: { repo: sqliteRepo } });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.id).toBe("e1");
+  });
+
+  test("Issue #37 fix: --open returns only currently open PRs", async () => {
+    const db = getDatabase();
+
+    // Set up two PRs: one open, one that will be merged
+    upsertPRs(db, [
+      createTestPR({ number: 1, state: "open" }),
+      createTestPR({ number: 2, state: "open" }),
+    ]);
+
+    insertEntries(db, [
+      createTestEntry({ id: "e1", pr: 1 }),
+      createTestEntry({ id: "e2", pr: 2 }),
+    ]);
+
+    setSyncMeta(db, {
+      repo: sqliteRepo,
+      last_sync: "2025-01-15T00:00:00Z",
+      pr_count: 2,
+    });
+
+    // Initially both PRs are open
+    let results = await queryEntries({
+      filters: { repo: sqliteRepo, states: ["open"] },
+    });
+    expect(results).toHaveLength(2);
+
+    // Merge PR 2 (simulating what happens during sync)
+    updatePRState(db, sqliteRepo, 2, "merged");
+
+    // Now --open should only return PR 1
+    results = await queryEntries({
+      filters: { repo: sqliteRepo, states: ["open"] },
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.pr).toBe(1);
+    expect(results[0]?.pr_state).toBe("open");
+
+    // --merged should return PR 2 with updated state
+    results = await queryEntries({
+      filters: { repo: sqliteRepo, states: ["merged"] },
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.pr).toBe(2);
+    expect(results[0]?.pr_state).toBe("merged");
+  });
+
+  test("pr_state reflects current PR state, not sync-time state", async () => {
+    const db = getDatabase();
+
+    // Create a PR that was initially open
+    upsertPRs(db, [createTestPR({ number: 1, state: "open" })]);
+    insertEntries(db, [
+      createTestEntry({
+        id: "e1",
+        pr: 1,
+        pr_state: "open", // Entry was captured when PR was open
+      }),
+    ]);
+    setSyncMeta(db, {
+      repo: sqliteRepo,
+      last_sync: "2025-01-15T00:00:00Z",
+      pr_count: 1,
+    });
+
+    // Verify initial state
+    let results = await queryEntries({ filters: { repo: sqliteRepo } });
+    expect(results[0]?.pr_state).toBe("open");
+
+    // PR gets merged
+    updatePRState(db, sqliteRepo, 1, "merged");
+
+    // Entry should now show merged state (not the stale "open" from sync time)
+    results = await queryEntries({ filters: { repo: sqliteRepo } });
+    expect(results[0]?.pr_state).toBe("merged");
+  });
+
+  test("draft state filtering works correctly", async () => {
+    const db = getDatabase();
+
+    upsertPRs(db, [
+      createTestPR({ number: 1, state: "open", isDraft: false }),
+      createTestPR({ number: 2, state: "open", isDraft: true }),
+      createTestPR({ number: 3, state: "closed", isDraft: false }),
+    ]);
+
+    insertEntries(db, [
+      createTestEntry({ id: "e1", pr: 1 }),
+      createTestEntry({ id: "e2", pr: 2 }),
+      createTestEntry({ id: "e3", pr: 3 }),
+    ]);
+
+    setSyncMeta(db, {
+      repo: sqliteRepo,
+      last_sync: "2025-01-15T00:00:00Z",
+      pr_count: 3,
+    });
+
+    // --open should return only non-draft open PRs
+    let results = await queryEntries({
+      filters: { repo: sqliteRepo, states: ["open"] },
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.pr).toBe(1);
+
+    // --draft should return only draft PRs
+    results = await queryEntries({
+      filters: { repo: sqliteRepo, states: ["draft"] },
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.pr).toBe(2);
+    expect(results[0]?.pr_state).toBe("draft");
+  });
+
+  test("combined state filtering", async () => {
+    const db = getDatabase();
+
+    upsertPRs(db, [
+      createTestPR({ number: 1, state: "open", isDraft: false }),
+      createTestPR({ number: 2, state: "open", isDraft: true }),
+      createTestPR({ number: 3, state: "merged", isDraft: false }),
+      createTestPR({ number: 4, state: "closed", isDraft: false }),
+    ]);
+
+    insertEntries(db, [
+      createTestEntry({ id: "e1", pr: 1 }),
+      createTestEntry({ id: "e2", pr: 2 }),
+      createTestEntry({ id: "e3", pr: 3 }),
+      createTestEntry({ id: "e4", pr: 4 }),
+    ]);
+
+    setSyncMeta(db, {
+      repo: sqliteRepo,
+      last_sync: "2025-01-15T00:00:00Z",
+      pr_count: 4,
+    });
+
+    // --open --draft should return both
+    const results = await queryEntries({
+      filters: { repo: sqliteRepo, states: ["open", "draft"] },
+    });
+    expect(results).toHaveLength(2);
+    const prs = results.map((r) => r.pr).toSorted();
+    expect(prs).toEqual([1, 2]);
+  });
 });

--- a/packages/core/tests/sync.test.ts
+++ b/packages/core/tests/sync.test.ts
@@ -1,0 +1,386 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { closeDatabase, openDatabase } from "../src/db";
+import {
+  countEntries,
+  getPR,
+  getSyncMeta,
+  insertEntries,
+  queryEntries,
+  setSyncMeta,
+  upsertPR,
+  upsertPRs,
+  type PRMetadata,
+} from "../src/repository";
+import type { FirewatchEntry } from "../src/schema/entry";
+
+const tempRoot = await mkdtemp(join(tmpdir(), "firewatch-sync-"));
+
+afterAll(async () => {
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+// =============================================================================
+// Test Fixtures - Simulating GitHub API data
+// =============================================================================
+
+function createPRMetadata(overrides: Partial<PRMetadata> = {}): PRMetadata {
+  return {
+    repo: "owner/repo",
+    number: 1,
+    state: "open",
+    isDraft: false,
+    title: "Test PR",
+    author: "testuser",
+    branch: "feature/test",
+    labels: ["bug", "enhancement"],
+    updatedAt: "2025-01-15T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function createEntry(overrides: Partial<FirewatchEntry> = {}): FirewatchEntry {
+  return {
+    id: "entry-1",
+    repo: "owner/repo",
+    pr: 1,
+    pr_title: "Test PR",
+    pr_state: "open",
+    pr_author: "testuser",
+    pr_branch: "feature/test",
+    pr_labels: ["bug", "enhancement"],
+    type: "comment",
+    subtype: "issue_comment",
+    author: "commenter",
+    body: "LGTM",
+    created_at: "2025-01-15T00:00:00Z",
+    updated_at: "2025-01-15T01:00:00Z",
+    captured_at: "2025-01-15T02:00:00Z",
+    url: "https://github.com/owner/repo/pull/1#issuecomment-123",
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// PR State Update Tests (Issue #37 fix)
+// =============================================================================
+
+describe("PR State Updates (Issue #37)", () => {
+  test("upsertPR updates state when PR is merged", () => {
+    const db = openDatabase();
+
+    // Initial sync: PR is open
+    upsertPR(db, createPRMetadata({ state: "open", isDraft: false }));
+    let pr = getPR(db, "owner/repo", 1);
+    expect(pr?.state).toBe("open");
+    expect(pr?.isDraft).toBe(false);
+
+    // Subsequent sync: PR was merged
+    upsertPR(db, createPRMetadata({ state: "merged", isDraft: false }));
+    pr = getPR(db, "owner/repo", 1);
+    expect(pr?.state).toBe("merged");
+
+    closeDatabase(db);
+  });
+
+  test("upsertPR updates state when PR is closed", () => {
+    const db = openDatabase();
+
+    // Initial sync: PR is open
+    upsertPR(db, createPRMetadata({ state: "open" }));
+    let pr = getPR(db, "owner/repo", 1);
+    expect(pr?.state).toBe("open");
+
+    // Subsequent sync: PR was closed
+    upsertPR(db, createPRMetadata({ state: "closed" }));
+    pr = getPR(db, "owner/repo", 1);
+    expect(pr?.state).toBe("closed");
+
+    closeDatabase(db);
+  });
+
+  test("upsertPR updates isDraft when PR is marked ready", () => {
+    const db = openDatabase();
+
+    // Initial sync: PR is draft
+    upsertPR(db, createPRMetadata({ state: "open", isDraft: true }));
+    let pr = getPR(db, "owner/repo", 1);
+    expect(pr?.state).toBe("open");
+    expect(pr?.isDraft).toBe(true);
+
+    // Subsequent sync: PR is now ready
+    upsertPR(db, createPRMetadata({ state: "open", isDraft: false }));
+    pr = getPR(db, "owner/repo", 1);
+    expect(pr?.state).toBe("open");
+    expect(pr?.isDraft).toBe(false);
+
+    closeDatabase(db);
+  });
+
+  test("upsertPR preserves PR metadata on state update", () => {
+    const db = openDatabase();
+
+    // Initial sync with full metadata
+    upsertPR(
+      db,
+      createPRMetadata({
+        state: "open",
+        title: "Original Title",
+        author: "alice",
+        branch: "feature/test",
+        labels: ["bug"],
+      })
+    );
+
+    // Subsequent sync updates state but keeps metadata
+    upsertPR(
+      db,
+      createPRMetadata({
+        state: "merged",
+        title: "Updated Title",
+        author: "alice",
+        branch: "feature/test",
+        labels: ["bug", "merged"],
+      })
+    );
+
+    const pr = getPR(db, "owner/repo", 1);
+    expect(pr?.state).toBe("merged");
+    expect(pr?.title).toBe("Updated Title");
+    expect(pr?.labels).toEqual(["bug", "merged"]);
+
+    closeDatabase(db);
+  });
+});
+
+// =============================================================================
+// Entry Query with Current PR State
+// =============================================================================
+
+describe("Entry Queries with Current PR State", () => {
+  test("queryEntries reflects current PR state, not entry-time state", () => {
+    const db = openDatabase();
+
+    // Insert PR as open
+    upsertPR(db, createPRMetadata({ state: "open", isDraft: false }));
+
+    // Insert entry (captured when PR was open)
+    insertEntries(db, [createEntry({ pr_state: "open" })]);
+
+    // Initial query shows open
+    let entries = queryEntries(db, { pr: 1 });
+    expect(entries[0]?.pr_state).toBe("open");
+
+    // PR is merged (simulating a subsequent sync)
+    upsertPR(db, createPRMetadata({ state: "merged" }));
+
+    // Same entry now shows merged state
+    entries = queryEntries(db, { pr: 1 });
+    expect(entries[0]?.pr_state).toBe("merged");
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries with --open filter excludes merged PRs", () => {
+    const db = openDatabase();
+
+    // Insert two PRs
+    upsertPR(
+      db,
+      createPRMetadata({ number: 1, state: "open", isDraft: false })
+    );
+    upsertPR(
+      db,
+      createPRMetadata({ number: 2, state: "open", isDraft: false })
+    );
+
+    // Insert entries for both
+    insertEntries(db, [
+      createEntry({ id: "e1", pr: 1 }),
+      createEntry({ id: "e2", pr: 2 }),
+    ]);
+
+    // Both PRs are open
+    let openEntries = queryEntries(db, { states: ["open"] });
+    expect(openEntries).toHaveLength(2);
+
+    // PR 2 gets merged
+    upsertPR(db, createPRMetadata({ number: 2, state: "merged" }));
+
+    // Now only PR 1 entries show with --open
+    openEntries = queryEntries(db, { states: ["open"] });
+    expect(openEntries).toHaveLength(1);
+    expect(openEntries[0]?.pr).toBe(1);
+
+    closeDatabase(db);
+  });
+
+  test("queryEntries with --open filter excludes draft PRs", () => {
+    const db = openDatabase();
+
+    // One open, one draft
+    upsertPR(
+      db,
+      createPRMetadata({ number: 1, state: "open", isDraft: false })
+    );
+    upsertPR(db, createPRMetadata({ number: 2, state: "open", isDraft: true }));
+
+    insertEntries(db, [
+      createEntry({ id: "e1", pr: 1 }),
+      createEntry({ id: "e2", pr: 2 }),
+    ]);
+
+    // Only non-draft open PRs
+    const openEntries = queryEntries(db, { states: ["open"] });
+    expect(openEntries).toHaveLength(1);
+    expect(openEntries[0]?.pr).toBe(1);
+
+    // Draft PRs show with draft filter
+    const draftEntries = queryEntries(db, { states: ["draft"] });
+    expect(draftEntries).toHaveLength(1);
+    expect(draftEntries[0]?.pr).toBe(2);
+    expect(draftEntries[0]?.pr_state).toBe("draft");
+
+    closeDatabase(db);
+  });
+});
+
+// =============================================================================
+// Sync Metadata Tests
+// =============================================================================
+
+describe("Sync Metadata", () => {
+  test("sync metadata is stored correctly", () => {
+    const db = openDatabase();
+
+    setSyncMeta(db, {
+      repo: "owner/repo",
+      cursor: "Y3Vyc29yOjEyMw==",
+      last_sync: "2025-01-15T00:00:00Z",
+      pr_count: 42,
+    });
+
+    const meta = getSyncMeta(db, "owner/repo");
+    expect(meta?.repo).toBe("owner/repo");
+    expect(meta?.cursor).toBe("Y3Vyc29yOjEyMw==");
+    expect(meta?.pr_count).toBe(42);
+
+    closeDatabase(db);
+  });
+
+  test("sync metadata updates on subsequent syncs", () => {
+    const db = openDatabase();
+
+    // First sync
+    setSyncMeta(db, {
+      repo: "owner/repo",
+      cursor: "cursor1",
+      last_sync: "2025-01-15T00:00:00Z",
+      pr_count: 10,
+    });
+
+    // Second sync
+    setSyncMeta(db, {
+      repo: "owner/repo",
+      cursor: "cursor2",
+      last_sync: "2025-01-16T00:00:00Z",
+      pr_count: 20,
+    });
+
+    const meta = getSyncMeta(db, "owner/repo");
+    expect(meta?.cursor).toBe("cursor2");
+    expect(meta?.pr_count).toBe(20);
+
+    closeDatabase(db);
+  });
+});
+
+// =============================================================================
+// Transaction Atomicity Tests
+// =============================================================================
+
+describe("Transaction Atomicity", () => {
+  test("multiple PRs and entries are written atomically", () => {
+    const db = openDatabase();
+
+    const prs = [
+      createPRMetadata({ number: 1, title: "PR 1" }),
+      createPRMetadata({ number: 2, title: "PR 2" }),
+      createPRMetadata({ number: 3, title: "PR 3" }),
+    ];
+
+    const entries = [
+      createEntry({ id: "e1", pr: 1 }),
+      createEntry({ id: "e2", pr: 1 }),
+      createEntry({ id: "e3", pr: 2 }),
+      createEntry({ id: "e4", pr: 3 }),
+    ];
+
+    // Simulate batch write from sync
+    db.transaction(() => {
+      upsertPRs(db, prs);
+      insertEntries(db, entries);
+    })();
+
+    // All PRs should exist
+    expect(getPR(db, "owner/repo", 1)).not.toBeNull();
+    expect(getPR(db, "owner/repo", 2)).not.toBeNull();
+    expect(getPR(db, "owner/repo", 3)).not.toBeNull();
+
+    // All entries should exist
+    expect(countEntries(db)).toBe(4);
+
+    closeDatabase(db);
+  });
+});
+
+// =============================================================================
+// mapPRStateForDb Tests (exported for unit testing)
+// =============================================================================
+
+describe("State Mapping", () => {
+  test("GitHub OPEN state maps to 'open'", () => {
+    const db = openDatabase();
+
+    // Simulating what sync does: GitHub returns OPEN
+    upsertPR(db, createPRMetadata({ state: "open" }));
+    const pr = getPR(db, "owner/repo", 1);
+    expect(pr?.state).toBe("open");
+
+    closeDatabase(db);
+  });
+
+  test("GitHub CLOSED state maps to 'closed'", () => {
+    const db = openDatabase();
+
+    upsertPR(db, createPRMetadata({ state: "closed" }));
+    const pr = getPR(db, "owner/repo", 1);
+    expect(pr?.state).toBe("closed");
+
+    closeDatabase(db);
+  });
+
+  test("GitHub MERGED state maps to 'merged'", () => {
+    const db = openDatabase();
+
+    upsertPR(db, createPRMetadata({ state: "merged" }));
+    const pr = getPR(db, "owner/repo", 1);
+    expect(pr?.state).toBe("merged");
+
+    closeDatabase(db);
+  });
+
+  test("Draft PRs have state 'open' with isDraft true", () => {
+    const db = openDatabase();
+
+    upsertPR(db, createPRMetadata({ state: "open", isDraft: true }));
+    const pr = getPR(db, "owner/repo", 1);
+    expect(pr?.state).toBe("open");
+    expect(pr?.isDraft).toBe(true);
+
+    closeDatabase(db);
+  });
+});


### PR DESCRIPTION
Refactor core modules to use SQLite storage, fixing issue #37.

Changes:
- sync.ts: Write to SQLite via repository layer, upsert PR metadata
- query.ts: Use SQL JOINs to derive pr_state from current PR metadata
- check.ts: Update file_activity in SQLite instead of rewriting files
- cache.ts: Add database singleton (getDatabase, closeFirewatchDb)
- index.ts: Export new database functions

The key fix: PR state is now read from the `prs` table at query time,
not stored in entries. When a PR is merged/closed, subsequent queries
correctly reflect the new state.

Before: `--open` could return entries from merged PRs (stale state)
After: `--open` queries `prs.state = 'open'` (current state)

Closes #37

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>