### PR TITLE
feat: add --orphaned flag to find unresolved comments on closed/merged PRs

### DIFF
--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -22,6 +22,15 @@ interface AddCommandOptions {
   json?: boolean;
 }
 
+interface AddContext {
+  client: GitHubClient;
+  owner: string;
+  name: string;
+  repo: string;
+  pr: number;
+  outputJson: boolean;
+}
+
 function collect(value: string, previous: string[] = []): string[] {
   return [...previous, value];
 }
@@ -38,6 +47,159 @@ function normalizeReviewEvent(value: string): ReviewEvent {
     );
   }
   return normalized as ReviewEvent;
+}
+
+async function handleReviewAction(
+  ctx: AddContext,
+  reviewType: string,
+  body: string | undefined
+): Promise<void> {
+  const event = normalizeReviewEvent(reviewType);
+  const review = await ctx.client.addReview(
+    ctx.owner,
+    ctx.name,
+    ctx.pr,
+    event,
+    body
+  );
+  const payload = {
+    ok: true,
+    repo: ctx.repo,
+    pr: ctx.pr,
+    review: event,
+    ...(review?.id && { review_id: review.id }),
+    ...(review?.url && { url: review.url }),
+  };
+
+  if (ctx.outputJson) {
+    await writeJsonLine(payload);
+  } else {
+    console.log(`Added ${event} review on ${ctx.repo}#${ctx.pr}.`);
+  }
+}
+
+async function handleMetadataAction(
+  ctx: AddContext,
+  labels: string[],
+  reviewers: string[],
+  assignees: string[]
+): Promise<void> {
+  if (labels.length > 0) {
+    await ctx.client.addLabels(ctx.owner, ctx.name, ctx.pr, labels);
+  }
+  if (reviewers.length > 0) {
+    await ctx.client.requestReviewers(ctx.owner, ctx.name, ctx.pr, reviewers);
+  }
+  if (assignees.length > 0) {
+    await ctx.client.addAssignees(ctx.owner, ctx.name, ctx.pr, assignees);
+  }
+
+  const payload = {
+    ok: true,
+    repo: ctx.repo,
+    pr: ctx.pr,
+    ...(labels.length > 0 && { labels_added: labels }),
+    ...(reviewers.length > 0 && { reviewers_added: reviewers }),
+    ...(assignees.length > 0 && { assignees_added: assignees }),
+  };
+
+  if (ctx.outputJson) {
+    await writeJsonLine(payload);
+  } else {
+    console.log(`Updated ${ctx.repo}#${ctx.pr}.`);
+  }
+}
+
+async function handleReplyAction(
+  ctx: AddContext,
+  replyTo: string,
+  body: string,
+  resolve: boolean
+): Promise<void> {
+  const threadMap = await ctx.client.fetchReviewThreadMap(
+    ctx.owner,
+    ctx.name,
+    ctx.pr
+  );
+  const threadId = threadMap.get(replyTo);
+  if (!threadId) {
+    console.error(`No review thread found for comment ${replyTo}.`);
+    process.exit(1);
+  }
+
+  const reply = await ctx.client.addReviewThreadReply(threadId, body);
+  if (resolve) {
+    await ctx.client.resolveReviewThread(threadId);
+  }
+
+  const payload = {
+    ok: true,
+    repo: ctx.repo,
+    pr: ctx.pr,
+    comment_id: reply.id,
+    reply_to: replyTo,
+    ...(resolve && { resolved: true }),
+    ...(reply.url && { url: reply.url }),
+  };
+
+  if (ctx.outputJson) {
+    await writeJsonLine(payload);
+  } else {
+    console.log(`Replied to ${replyTo} on ${ctx.repo}#${ctx.pr}.`);
+  }
+}
+
+async function handleCommentAction(
+  ctx: AddContext,
+  body: string
+): Promise<void> {
+  const prId = await ctx.client.fetchPullRequestId(ctx.owner, ctx.name, ctx.pr);
+  const comment = await ctx.client.addIssueComment(prId, body);
+
+  const payload = {
+    ok: true,
+    repo: ctx.repo,
+    pr: ctx.pr,
+    comment_id: comment.id,
+    ...(comment.url && { url: comment.url }),
+  };
+
+  if (ctx.outputJson) {
+    await writeJsonLine(payload);
+  } else {
+    console.log(`Added comment to ${ctx.repo}#${ctx.pr}.`);
+  }
+}
+
+function validateOptions(
+  options: AddCommandOptions,
+  body: string | undefined,
+  hasMetadata: boolean,
+  hasReview: boolean
+): void {
+  if (options.resolve && !options.reply) {
+    console.error("--resolve requires --reply.");
+    process.exit(1);
+  }
+
+  if (hasReview && hasMetadata) {
+    console.error(
+      "Review actions cannot be combined with label/reviewer/assignee updates."
+    );
+    process.exit(1);
+  }
+
+  if (!hasReview && !hasMetadata && !body) {
+    console.error("Comment body is required.");
+    process.exit(1);
+  }
+
+  if (hasMetadata && body) {
+    console.error(
+      "Remove the body argument when adding labels/reviewers/assignees."
+    );
+    process.exit(1);
+  }
 }
 
 export const addCommand = new Command("add")
@@ -60,11 +222,6 @@ export const addCommand = new Command("add")
       options: AddCommandOptions
     ) => {
       try {
-        if (options.resolve && !options.reply) {
-          console.error("--resolve requires --reply.");
-          process.exit(1);
-        }
-
         const labels = options.label ?? [];
         const reviewers = options.reviewer ?? [];
         const assignees = options.assignee ?? [];
@@ -72,24 +229,7 @@ export const addCommand = new Command("add")
           labels.length > 0 || reviewers.length > 0 || assignees.length > 0;
         const hasReview = Boolean(options.review);
 
-        if (hasReview && hasMetadata) {
-          console.error(
-            "Review actions cannot be combined with label/reviewer/assignee updates."
-          );
-          process.exit(1);
-        }
-
-        if (!hasReview && !hasMetadata && !body) {
-          console.error("Comment body is required.");
-          process.exit(1);
-        }
-
-        if (hasMetadata && body) {
-          console.error(
-            "Remove the body argument when adding labels/reviewers/assignees."
-          );
-          process.exit(1);
-        }
+        validateOptions(options, body, hasMetadata, hasReview);
 
         const config = await loadConfig();
         const repo = await resolveRepoOrThrow(options.repo);
@@ -101,109 +241,36 @@ export const addCommand = new Command("add")
           process.exit(1);
         }
 
-        const client = new GitHubClient(auth.token);
-        const outputJson = shouldOutputJson(
-          options,
-          config.output?.default_format
-        );
+        const ctx: AddContext = {
+          client: new GitHubClient(auth.token),
+          owner,
+          name,
+          repo,
+          pr,
+          outputJson: shouldOutputJson(options, config.output?.default_format),
+        };
 
         if (hasReview) {
-          const event = normalizeReviewEvent(options.review!);
-          const review = await client.addReview(owner, name, pr, event, body);
-          const payload = {
-            ok: true,
-            repo,
-            pr,
-            review: event,
-            ...(review?.id && { review_id: review.id }),
-            ...(review?.url && { url: review.url }),
-          };
-
-          if (outputJson) {
-            await writeJsonLine(payload);
-          } else {
-            console.log(`Added ${event} review on ${repo}#${pr}.`);
-          }
+          await handleReviewAction(ctx, options.review!, body);
           return;
         }
 
         if (hasMetadata) {
-          if (labels.length > 0) {
-            await client.addLabels(owner, name, pr, labels);
-          }
-          if (reviewers.length > 0) {
-            await client.requestReviewers(owner, name, pr, reviewers);
-          }
-          if (assignees.length > 0) {
-            await client.addAssignees(owner, name, pr, assignees);
-          }
-
-          const payload = {
-            ok: true,
-            repo,
-            pr,
-            ...(labels.length > 0 && { labels_added: labels }),
-            ...(reviewers.length > 0 && { reviewers_added: reviewers }),
-            ...(assignees.length > 0 && { assignees_added: assignees }),
-          };
-
-          if (outputJson) {
-            await writeJsonLine(payload);
-          } else {
-            console.log(`Updated ${repo}#${pr}.`);
-          }
+          await handleMetadataAction(ctx, labels, reviewers, assignees);
           return;
         }
 
         if (options.reply) {
-          const threadMap = await client.fetchReviewThreadMap(owner, name, pr);
-          const threadId = threadMap.get(options.reply);
-          if (!threadId) {
-            console.error(
-              `No review thread found for comment ${options.reply}.`
-            );
-            process.exit(1);
-          }
-
-          const reply = await client.addReviewThreadReply(threadId, body ?? "");
-          if (options.resolve) {
-            await client.resolveReviewThread(threadId);
-          }
-
-          const payload = {
-            ok: true,
-            repo,
-            pr,
-            comment_id: reply.id,
-            reply_to: options.reply,
-            ...(options.resolve && { resolved: true }),
-            ...(reply.url && { url: reply.url }),
-          };
-
-          if (outputJson) {
-            await writeJsonLine(payload);
-          } else {
-            console.log(`Replied to ${options.reply} on ${repo}#${pr}.`);
-          }
+          await handleReplyAction(
+            ctx,
+            options.reply,
+            body ?? "",
+            Boolean(options.resolve)
+          );
           return;
         }
 
-        const prId = await client.fetchPullRequestId(owner, name, pr);
-        const comment = await client.addIssueComment(prId, body ?? "");
-
-        const payload = {
-          ok: true,
-          repo,
-          pr,
-          comment_id: comment.id,
-          ...(comment.url && { url: comment.url }),
-        };
-
-        if (outputJson) {
-          await writeJsonLine(payload);
-        } else {
-          console.log(`Added comment to ${repo}#${pr}.`);
-        }
+        await handleCommentAction(ctx, body ?? "");
       } catch (error) {
         console.error(
           "Add failed:",

--- a/apps/cli/src/commands/cache.ts
+++ b/apps/cli/src/commands/cache.ts
@@ -124,45 +124,45 @@ const clearSubcommand = new Command("clear")
       // Remove main database file
       try {
         await rm(PATHS.db, { force: true });
-      } catch (err) {
+      } catch (error) {
         errors.push(
-          `Database: ${err instanceof Error ? err.message : String(err)}`
+          `Database: ${error instanceof Error ? error.message : String(error)}`
         );
       }
 
       // Remove WAL file
       try {
         await rm(`${PATHS.db}-wal`, { force: true });
-      } catch (err) {
+      } catch (error) {
         errors.push(
-          `WAL file: ${err instanceof Error ? err.message : String(err)}`
+          `WAL file: ${error instanceof Error ? error.message : String(error)}`
         );
       }
 
       // Remove SHM file
       try {
         await rm(`${PATHS.db}-shm`, { force: true });
-      } catch (err) {
+      } catch (error) {
         errors.push(
-          `SHM file: ${err instanceof Error ? err.message : String(err)}`
+          `SHM file: ${error instanceof Error ? error.message : String(error)}`
         );
       }
 
       // Remove legacy JSONL cache directory
       try {
         await rm(PATHS.repos, { recursive: true, force: true });
-      } catch (err) {
+      } catch (error) {
         errors.push(
-          `JSONL cache: ${err instanceof Error ? err.message : String(err)}`
+          `JSONL cache: ${error instanceof Error ? error.message : String(error)}`
         );
       }
 
       // Remove legacy meta file
       try {
         await rm(PATHS.meta, { force: true });
-      } catch (err) {
+      } catch (error) {
         errors.push(
-          `Meta file: ${err instanceof Error ? err.message : String(err)}`
+          `Meta file: ${error instanceof Error ? error.message : String(error)}`
         );
       }
 

--- a/apps/cli/src/utils/states.ts
+++ b/apps/cli/src/utils/states.ts
@@ -8,6 +8,7 @@ export interface StateOptions {
   closed?: boolean;
   draft?: boolean;
   active?: boolean;
+  orphaned?: boolean;
 }
 
 export function parseStates(value: string): PrState[] {
@@ -49,6 +50,11 @@ export function resolveStates(options: StateOptions): PrState[] {
 
   if (states.size > 0) {
     return [...states];
+  }
+
+  // Orphaned implies merged/closed PRs (unresolved comments on finished PRs)
+  if (options.orphaned) {
+    return ["closed", "merged"];
   }
 
   return ["open", "draft"];

--- a/packages/core/src/check.ts
+++ b/packages/core/src/check.ts
@@ -160,7 +160,8 @@ export async function checkRepoDb(
   let entriesUpdated = 0;
 
   // Track updates for batch processing
-  const updates: { id: string; activity: FileActivityAfter }[] = [];
+  const updates: { id: string; repo: string; activity: FileActivityAfter }[] =
+    [];
 
   for (const entry of entries) {
     if (entry.type !== "comment") {

--- a/packages/core/src/github.ts
+++ b/packages/core/src/github.ts
@@ -62,6 +62,7 @@ query PRActivity($owner: String!, $repo: String!, $first: Int!, $after: String, 
         reviewThreads(first: 100) {
           nodes {
             id
+            isResolved
             path
             line
             comments(first: 50) {
@@ -379,6 +380,7 @@ export interface PRNode {
   reviewThreads: {
     nodes: {
       id: string;
+      isResolved: boolean;
       path: string;
       line: number | null;
       comments: {

--- a/packages/core/src/schema/entry.ts
+++ b/packages/core/src/schema/entry.ts
@@ -92,6 +92,10 @@ export const FirewatchEntrySchema = z.object({
   file_activity_after: FileActivityAfterSchema.optional(),
   file_provenance: FileProvenanceSchema.optional(),
 
+  // Thread resolution (for review_comment entries)
+  // true = resolved, false = unresolved, undefined = unknown/not applicable
+  thread_resolved: z.boolean().optional(),
+
   // Plugin data
   graphite: GraphiteMetadataSchema.optional(),
 });

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -134,6 +134,8 @@ function reviewThreadEntries(
         url: pr.url,
         file: thread.path,
         line: thread.line ?? undefined,
+        // Track thread resolution state for orphaned comment detection
+        thread_resolved: thread.isResolved,
       });
     }
   }


### PR DESCRIPTION
Implements GitHub issue #43. The --orphaned flag surfaces review comments
that were never resolved before the PR was merged/closed.

Changes:
- GraphQL: Fetch isResolved field from PullRequestReviewThread
- SQLite: Schema v1→v2 migration adds thread_resolved column with index
- Repository: Orphaned filter (thread_resolved=false + merged/closed state)
- Schema: Add thread_resolved boolean to FirewatchEntry
- Sync: Capture isResolved from thread during sync
- CLI: --orphaned flag (defaults to 7d since, conflicts with --open)
- MCP: orphaned parameter support with same defaults

Re-sync required for existing data to populate thread_resolved field.

Closes #43

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>