### PR TITLE
fix: use XDG paths when set, otherwise ~/.firewatch/ on macOS

### DIFF
--- a/apps/cli/tests/command.test.ts
+++ b/apps/cli/tests/command.test.ts
@@ -14,18 +14,13 @@ import {
 } from "@outfitter/firewatch-core";
 
 const tempRoot = await mkdtemp(join(tmpdir(), "firewatch-cli-"));
-const paths =
-  process.platform === "darwin"
-    ? {
-        cache: join(tempRoot, "Library", "Caches", "firewatch"),
-        config: join(tempRoot, "Library", "Preferences", "firewatch"),
-        data: join(tempRoot, "Library", "Application Support", "firewatch"),
-      }
-    : {
-        cache: join(tempRoot, ".cache", "firewatch"),
-        config: join(tempRoot, ".config", "firewatch"),
-        data: join(tempRoot, ".local", "share", "firewatch"),
-      };
+
+// Test always sets XDG vars for spawned CLI, so use XDG paths
+const paths = {
+  cache: join(tempRoot, ".cache", "firewatch"),
+  config: join(tempRoot, ".config", "firewatch"),
+  data: join(tempRoot, ".local", "share", "firewatch"),
+};
 
 await mkdir(paths.cache, { recursive: true });
 await mkdir(paths.config, { recursive: true });
@@ -145,6 +140,10 @@ async function runCli(args: string[]): Promise<{ stdout: string; stderr: string;
     env: {
       ...process.env,
       HOME: tempRoot,
+      // Override XDG vars to use test paths (matches path computation above)
+      XDG_CONFIG_HOME: join(tempRoot, ".config"),
+      XDG_CACHE_HOME: join(tempRoot, ".cache"),
+      XDG_DATA_HOME: join(tempRoot, ".local", "share"),
     },
     stdout: "pipe",
     stderr: "pipe",

--- a/apps/cli/tests/smoke.test.ts
+++ b/apps/cli/tests/smoke.test.ts
@@ -14,18 +14,13 @@ import {
 } from "@outfitter/firewatch-core";
 
 const tempRoot = await mkdtemp(join(tmpdir(), "firewatch-cli-smoke-"));
-const paths =
-  process.platform === "darwin"
-    ? {
-        cache: join(tempRoot, "Library", "Caches", "firewatch"),
-        config: join(tempRoot, "Library", "Preferences", "firewatch"),
-        data: join(tempRoot, "Library", "Application Support", "firewatch"),
-      }
-    : {
-        cache: join(tempRoot, ".cache", "firewatch"),
-        config: join(tempRoot, ".config", "firewatch"),
-        data: join(tempRoot, ".local", "share", "firewatch"),
-      };
+
+// Test always sets XDG vars for spawned CLI, so use XDG paths
+const paths = {
+  cache: join(tempRoot, ".cache", "firewatch"),
+  config: join(tempRoot, ".config", "firewatch"),
+  data: join(tempRoot, ".local", "share", "firewatch"),
+};
 
 await mkdir(paths.cache, { recursive: true });
 await mkdir(paths.config, { recursive: true });
@@ -91,6 +86,10 @@ test("cli smoke runs root command against cached data", async () => {
     env: {
       ...process.env,
       HOME: tempRoot,
+      // Override XDG vars to use test paths
+      XDG_CONFIG_HOME: join(tempRoot, ".config"),
+      XDG_CACHE_HOME: join(tempRoot, ".cache"),
+      XDG_DATA_HOME: join(tempRoot, ".local", "share"),
     },
     stdout: "pipe",
     stderr: "pipe",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,6 @@
     "check": "bunx tsc --noEmit"
   },
   "dependencies": {
-    "env-paths": "^3.0.0",
     "zod": "^4.3.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Path resolution now follows user intent:
1. If XDG env vars are set (any platform), use them
2. macOS without XDG: use ~/.firewatch/ (simple dotfile)
3. Linux: use XDG defaults (~/.config, ~/.cache, ~/.local/share)

This replaces env-paths which used macOS Library paths by default,
ignoring user XDG configuration.

Also updates CLI tests to properly set XDG vars when spawning
the CLI subprocess.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>