### PR TITLE
fix: use explicit null checks in repository hydration

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,9 +1,6 @@
-import { existsSync, readdirSync } from "node:fs";
-
 import {
   ENTRY_TYPES,
   GitHubClient,
-  PATHS,
   countEntries,
   detectAuth,
   detectRepo,
@@ -15,7 +12,6 @@ import {
   mergeExcludeAuthors,
   parseDurationMs,
   parseSince,
-  parseRepoCacheFilename,
   queryEntries,
   syncRepo,
   type FirewatchConfig,
@@ -219,13 +215,10 @@ function resolveAuthorFilters(
 }
 
 function listCachedRepos(): string[] {
-  if (!existsSync(PATHS.repos)) {
-    return [];
-  }
-  const files = readdirSync(PATHS.repos).filter((f) => f.endsWith(".jsonl"));
-  return files
-    .map((file) => parseRepoCacheFilename(file.replace(".jsonl", "")))
-    .filter((repo): repo is string => repo !== null);
+  const db = getDatabase();
+  // Use sync_meta to include repos that may have no entries yet
+  const syncMeta = getAllSyncMeta(db);
+  return syncMeta.map((m) => m.repo);
 }
 
 function resolveRepoFilter(

--- a/packages/core/src/repository.ts
+++ b/packages/core/src/repository.ts
@@ -201,24 +201,25 @@ function derivePrState(prState: string, isDraft: boolean): PrState {
 
 /**
  * Apply optional simple fields from row to entry.
+ * Uses explicit null checks to preserve empty strings as valid values.
  */
 function applyOptionalFields(entry: FirewatchEntry, row: EntryWithPRRow): void {
-  if (row.subtype) {
+  if (row.subtype !== null) {
     entry.subtype = row.subtype;
   }
-  if (row.body) {
+  if (row.body !== null) {
     entry.body = row.body;
   }
-  if (row.state) {
+  if (row.state !== null) {
     entry.state = row.state;
   }
-  if (row.updated_at) {
+  if (row.updated_at !== null) {
     entry.updated_at = row.updated_at;
   }
-  if (row.url) {
+  if (row.url !== null) {
     entry.url = row.url;
   }
-  if (row.file) {
+  if (row.file !== null) {
     entry.file = row.file;
   }
   if (row.line !== null) {


### PR DESCRIPTION
Preserve empty strings as valid values by using !== null checks instead of
truthy checks. This prevents data loss on round-trip for fields that may
legitimately contain empty strings.

Also clean up listCachedRepos() to use SQLite getRepos() instead of scanning
JSONL files, completing the SQLite migration.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>