### PR TITLE
feat(mcp): add server instructions for Tool Search discovery

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -1352,7 +1352,13 @@ firewatch_add - Add comments and metadata
 }
 
 export function createServer(): McpServer {
-  const server = new McpServer({ name: "firewatch", version: mcpVersion });
+  const server = new McpServer(
+    { name: "firewatch", version: mcpVersion },
+    {
+      instructions:
+        "Query GitHub PR activity including reviews, comments, commits, and CI status. Use when checking PR status, finding review comments, querying activity, resolving feedback, or working with GitHub pull requests. Outputs JSONL for jq composition.",
+    }
+  );
 
   // firewatch_query - Query cached PR activity
   server.tool(


### PR DESCRIPTION
## Summary
    - Expose MCP server instructions to improve Tool Search discovery.

    ## Changes
    - Add server instructions metadata for tool discovery.
- Document expected usage for the instructions payload.

    ## Testing
    - Not run (not requested)