### PR TITLE
feat(cli): rename --json to --jsonl

### DIFF
--- a/apps/cli/src/commands/cache.ts
+++ b/apps/cli/src/commands/cache.ts
@@ -9,11 +9,11 @@ import { Command } from "commander";
 import { existsSync, statSync } from "node:fs";
 import { rm } from "node:fs/promises";
 
-import { writeJsonLine } from "../utils/json";
+import { outputStructured } from "../utils/json";
 import { formatRelativeTime, shouldOutputJson } from "../utils/tty";
 
 interface CacheStatusOptions {
-  json?: boolean;
+  jsonl?: boolean;
 }
 
 interface CacheClearOptions {
@@ -56,8 +56,8 @@ function getDatabaseSize(): number {
 
 const statusSubcommand = new Command("status")
   .description("Show cache status and statistics")
-  .option("--json", "Force JSON output")
-  .option("--no-json", "Force human-readable output")
+  .option("--jsonl", "Force structured output")
+  .option("--no-jsonl", "Force human-readable output")
   .action(async (options: CacheStatusOptions) => {
     try {
       const db = getDatabase();
@@ -81,7 +81,7 @@ const statusSubcommand = new Command("status")
       };
 
       if (shouldOutputJson(options)) {
-        await writeJsonLine(payload);
+        await outputStructured(payload, "jsonl");
         return;
       }
 

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -13,12 +13,12 @@ import { Command } from "commander";
 import { constants as fsConstants } from "node:fs";
 import { access } from "node:fs/promises";
 
-import { writeJsonLine } from "../utils/json";
+import { outputStructured } from "../utils/json";
 import { MARKERS, renderHeader } from "../utils/tree";
 import { shouldOutputJson } from "../utils/tty";
 
 interface DoctorCommandOptions {
-  json?: boolean;
+  jsonl?: boolean;
   fix?: boolean;
 }
 
@@ -183,8 +183,8 @@ async function getGraphiteStackInfo(): Promise<{
 
 export const doctorCommand = new Command("doctor")
   .description("Diagnose Firewatch setup")
-  .option("--json", "Force JSON output")
-  .option("--no-json", "Force human-readable output")
+  .option("--jsonl", "Force structured output")
+  .option("--no-jsonl", "Force human-readable output")
   .option("--fix", "Attempt to fix issues automatically")
   .action(async (options: DoctorCommandOptions) => {
     try {
@@ -208,12 +208,15 @@ export const doctorCommand = new Command("doctor")
       const failCount = checks.length - okCount;
 
       if (shouldOutputJson(options, config.output?.default_format)) {
-        await writeJsonLine({
-          ok: failCount === 0,
-          checks,
-          graphite: graphiteInfo,
-          counts: { ok: okCount, failed: failCount },
-        });
+        await outputStructured(
+          {
+            ok: failCount === 0,
+            checks,
+            graphite: graphiteInfo,
+            counts: { ok: okCount, failed: failCount },
+          },
+          "jsonl"
+        );
         return;
       }
 

--- a/apps/cli/src/commands/fb.ts
+++ b/apps/cli/src/commands/fb.ts
@@ -23,7 +23,7 @@ import {
   type UnaddressedFeedback,
 } from "../actionable";
 import { parseRepoInput, resolveRepoOrThrow } from "../repo";
-import { writeJsonLine } from "../utils/json";
+import { outputStructured } from "../utils/json";
 import { shouldOutputJson } from "../utils/tty";
 
 interface FbCommandOptions {
@@ -32,7 +32,7 @@ interface FbCommandOptions {
   all?: boolean;
   ack?: boolean;
   resolve?: boolean;
-  json?: boolean;
+  jsonl?: boolean;
 }
 
 interface FbContext {
@@ -125,7 +125,7 @@ async function handleListAll(
     for (const fb of feedbacks) {
       const shortId = formatShortId(generateShortId(fb.comment_id, ctx.repo));
       const { comment_id: gh_id, ...rest } = fb;
-      await writeJsonLine({ ...rest, id: shortId, gh_id });
+      await outputStructured({ ...rest, id: shortId, gh_id }, "jsonl");
     }
     return;
   }
@@ -170,7 +170,7 @@ async function handlePrList(
       for (const c of comments) {
         const shortId = formatShortId(generateShortId(c.id, ctx.repo));
         const { id: gh_id, ...rest } = c;
-        await writeJsonLine({ ...rest, id: shortId, gh_id });
+        await outputStructured({ ...rest, id: shortId, gh_id }, "jsonl");
       }
       return;
     }
@@ -204,7 +204,7 @@ async function handlePrList(
     for (const fb of prFeedbacks) {
       const shortId = formatShortId(generateShortId(fb.comment_id, ctx.repo));
       const { comment_id: gh_id, ...rest } = fb;
-      await writeJsonLine({ ...rest, id: shortId, gh_id });
+      await outputStructured({ ...rest, id: shortId, gh_id }, "jsonl");
     }
     return;
   }
@@ -232,7 +232,7 @@ async function handlePrComment(
   };
 
   if (ctx.outputJson) {
-    await writeJsonLine(payload);
+    await outputStructured(payload, "jsonl");
   } else {
     console.log(
       `Added comment to ${ctx.repo}#${pr}. [${formatShortId(shortId)}]`
@@ -265,7 +265,7 @@ async function handleViewComment(
 
   if (ctx.outputJson) {
     const { id: gh_id, ...rest } = entry;
-    await writeJsonLine({ ...rest, id: formatShortId(sId), gh_id });
+    await outputStructured({ ...rest, id: formatShortId(sId), gh_id }, "jsonl");
     return;
   }
 
@@ -340,7 +340,7 @@ async function handleReplyToComment(
     };
 
     if (ctx.outputJson) {
-      await writeJsonLine(payload);
+      await outputStructured(payload, "jsonl");
     } else {
       const resolveMsg = options.resolve ? " and resolved thread" : "";
       console.log(
@@ -375,7 +375,7 @@ async function handleReplyToComment(
   };
 
   if (ctx.outputJson) {
-    await writeJsonLine(payload);
+    await outputStructured(payload, "jsonl");
   } else {
     console.log(`Added comment to ${ctx.repo}#${entry.pr}. [${newShortId}]`);
     if (comment.url) {
@@ -436,7 +436,7 @@ async function handleResolveComment(
   };
 
   if (ctx.outputJson) {
-    await writeJsonLine(payload);
+    await outputStructured(payload, "jsonl");
   } else {
     console.log(`Resolved thread for ${formatShortId(sId)}.`);
   }
@@ -493,7 +493,7 @@ async function handleAckComment(
   };
 
   if (ctx.outputJson) {
-    await writeJsonLine(payload);
+    await outputStructured(payload, "jsonl");
   } else {
     const reactionMsg = reactionAdded ? " (👍 added)" : "";
     console.log(`Acknowledged ${formatShortId(sId)}${reactionMsg}.`);
@@ -517,7 +517,10 @@ async function handleBulkAck(ctx: FbContext, pr: number): Promise<void> {
 
   if (prFeedbacks.length === 0) {
     if (ctx.outputJson) {
-      await writeJsonLine({ ok: true, repo: ctx.repo, pr, acked_count: 0 });
+      await outputStructured(
+        { ok: true, repo: ctx.repo, pr, acked_count: 0 },
+        "jsonl"
+      );
     } else {
       console.log(`No unaddressed feedback on PR #${pr}.`);
     }
@@ -573,7 +576,7 @@ async function handleBulkAck(ctx: FbContext, pr: number): Promise<void> {
   };
 
   if (ctx.outputJson) {
-    await writeJsonLine(payload);
+    await outputStructured(payload, "jsonl");
   } else {
     const reactionMsg =
       reactionsAdded > 0 ? ` (${reactionsAdded} 👍 added)` : "";
@@ -662,8 +665,8 @@ export const fbCommand = new Command("fb")
   .option("--all", "Show all feedback including resolved")
   .option("--ack", "Acknowledge feedback (👍 + local record)")
   .option("--resolve", "Resolve the thread after replying")
-  .option("--json", "Force JSON output")
-  .option("--no-json", "Force human-readable output")
+  .option("--jsonl", "Force structured output")
+  .option("--no-jsonl", "Force human-readable output")
   .action(
     async (
       id: string | undefined,

--- a/apps/cli/src/commands/pr/comment.ts
+++ b/apps/cli/src/commands/pr/comment.ts
@@ -6,12 +6,12 @@ import {
 import { Command } from "commander";
 
 import { parseRepoInput, parsePrNumber, resolveRepoOrThrow } from "../../repo";
-import { writeJsonLine } from "../../utils/json";
+import { outputStructured } from "../../utils/json";
 import { shouldOutputJson } from "../../utils/tty";
 
 interface CommentCommandOptions {
   repo?: string;
-  json?: boolean;
+  jsonl?: boolean;
 }
 
 export const commentCommand = new Command("comment")
@@ -19,8 +19,8 @@ export const commentCommand = new Command("comment")
   .argument("<pr>", "PR number", parsePrNumber)
   .argument("<body>", "Comment body")
   .option("--repo <name>", "Repository (owner/repo format)")
-  .option("--json", "Force JSON output")
-  .option("--no-json", "Force human-readable output")
+  .option("--jsonl", "Force structured output")
+  .option("--no-jsonl", "Force human-readable output")
   .action(async (pr: number, body: string, options: CommentCommandOptions) => {
     try {
       if (!body.trim()) {
@@ -56,7 +56,7 @@ export const commentCommand = new Command("comment")
       };
 
       if (outputJson) {
-        await writeJsonLine(payload);
+        await outputStructured(payload, "jsonl");
       } else {
         console.log(`Added comment to ${repo}#${pr}.`);
         if (comment.url) {

--- a/apps/cli/src/commands/pr/edit.ts
+++ b/apps/cli/src/commands/pr/edit.ts
@@ -6,7 +6,7 @@ import {
 import { Command } from "commander";
 
 import { parseRepoInput, parsePrNumber, resolveRepoOrThrow } from "../../repo";
-import { writeJsonLine } from "../../utils/json";
+import { outputStructured } from "../../utils/json";
 import { shouldOutputJson } from "../../utils/tty";
 
 interface EditCommandOptions {
@@ -24,7 +24,7 @@ interface EditCommandOptions {
   removeReviewer?: string[];
   addAssignee?: string[];
   removeAssignee?: string[];
-  json?: boolean;
+  jsonl?: boolean;
 }
 
 function collect(value: string, previous: string[] = []): string[] {
@@ -300,8 +300,8 @@ export const editCommand = new Command("edit")
   .option("--remove-reviewer <user>", "Remove reviewer (repeatable)", collect)
   .option("--add-assignee <user>", "Add assignee (repeatable)", collect)
   .option("--remove-assignee <user>", "Remove assignee (repeatable)", collect)
-  .option("--json", "Force JSON output")
-  .option("--no-json", "Force human-readable output")
+  .option("--jsonl", "Force structured output")
+  .option("--no-jsonl", "Force human-readable output")
   .action(async (pr: number, options: EditCommandOptions) => {
     try {
       // Validate conflicting options
@@ -364,7 +364,7 @@ export const editCommand = new Command("edit")
       };
 
       if (ctx.outputJson) {
-        await writeJsonLine(result);
+        await outputStructured(result, "jsonl");
       } else {
         console.log(formatHumanOutput(result));
       }

--- a/apps/cli/src/commands/pr/list.ts
+++ b/apps/cli/src/commands/pr/list.ts
@@ -33,7 +33,7 @@ import {
 } from "../../actionable";
 import { validateRepoFormat } from "../../repo";
 import { ensureGraphiteMetadata } from "../../stack";
-import { writeJsonLine } from "../../utils/json";
+import { outputStructured } from "../../utils/json";
 import { resolveStates } from "../../utils/states";
 import { shouldOutputJson } from "../../utils/tty";
 import { outputWorklist } from "../../worklist";
@@ -60,7 +60,7 @@ interface ListCommandOptions {
   limit?: number;
   offset?: number;
   summary?: boolean;
-  json?: boolean;
+  jsonl?: boolean;
   debug?: boolean;
   noColor?: boolean;
 }
@@ -406,8 +406,8 @@ export const listCommand = new Command("list")
   .option("-n, --limit <count>", "Limit number of results", Number.parseInt)
   .option("--offset <count>", "Skip first N results", Number.parseInt)
   .option("--summary", "Aggregate entries into per-PR summary")
-  .option("-j, --json", "Force JSON output")
-  .option("--no-json", "Force human-readable output")
+  .option("-j, --jsonl", "Force structured output")
+  .option("--no-jsonl", "Force human-readable output")
   .option("--debug", "Enable debug logging")
   .option("--no-color", "Disable color output")
   .action(async (options: ListCommandOptions) => {
@@ -573,7 +573,7 @@ export const listCommand = new Command("list")
           console.error("No entries matched the query filters.");
         }
         for (const entry of filtered) {
-          await writeJsonLine(entry);
+          await outputStructured(entry, "jsonl");
         }
         return;
       }

--- a/apps/cli/src/commands/pr/review.ts
+++ b/apps/cli/src/commands/pr/review.ts
@@ -6,7 +6,7 @@ import {
 import { Command } from "commander";
 
 import { parseRepoInput, parsePrNumber, resolveRepoOrThrow } from "../../repo";
-import { writeJsonLine } from "../../utils/json";
+import { outputStructured } from "../../utils/json";
 import { shouldOutputJson } from "../../utils/tty";
 
 type ReviewEvent = "approve" | "request-changes" | "comment";
@@ -17,7 +17,7 @@ interface ReviewCommandOptions {
   requestChanges?: boolean;
   comment?: boolean;
   body?: string;
-  json?: boolean;
+  jsonl?: boolean;
 }
 
 const EVENT_LABELS: Record<ReviewEvent, string> = {
@@ -92,8 +92,8 @@ export const reviewCommand = new Command("review")
     "-b, --body <text>",
     "Review body (required for --request-changes and --comment)"
   )
-  .option("--json", "Force JSON output")
-  .option("--no-json", "Force human-readable output")
+  .option("--jsonl", "Force structured output")
+  .option("--no-jsonl", "Force human-readable output")
   .action(async (pr: number, options: ReviewCommandOptions) => {
     try {
       const rawEvent = determineReviewEvent(options);
@@ -140,7 +140,7 @@ export const reviewCommand = new Command("review")
       };
 
       if (outputJson) {
-        await writeJsonLine(payload);
+        await outputStructured(payload, "jsonl");
       } else {
         console.log(`${EVENT_LABELS[event]} ${repo}#${pr}.`);
         if (review?.url) {

--- a/apps/cli/src/commands/schema.ts
+++ b/apps/cli/src/commands/schema.ts
@@ -5,6 +5,8 @@ import {
 } from "@outfitter/firewatch-core/schema";
 import { Command } from "commander";
 
+import { outputStructured } from "../utils/json";
+
 export type SchemaName = "entry" | "worklist" | "config";
 
 const schemaMap: Record<SchemaName, unknown> = {
@@ -13,20 +15,20 @@ const schemaMap: Record<SchemaName, unknown> = {
   config: CONFIG_SCHEMA_DOC,
 };
 
-export function printSchema(name: SchemaName): void {
+export async function printSchema(name: SchemaName): Promise<void> {
   const schema = schemaMap[name];
-  console.log(JSON.stringify(schema, null, 2));
+  await outputStructured(schema, "json");
 }
 
 export const schemaCommand = new Command("schema")
   .description("Print JSON schema for Firewatch data types")
   .argument("[name]", "Schema variant: entry, worklist, config", "entry")
-  .action((name: SchemaName) => {
+  .action(async (name: SchemaName) => {
     if (!schemaMap[name]) {
       console.error(
         `Unknown schema: ${name}. Valid schemas: entry, worklist, config`
       );
       process.exit(1);
     }
-    printSchema(name);
+    await printSchema(name);
   });

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -17,12 +17,12 @@ import { Command } from "commander";
 import { existsSync, statSync } from "node:fs";
 
 import { version } from "../../package.json";
-import { writeJsonLine } from "../utils/json";
+import { outputStructured } from "../utils/json";
 import { formatRelativeTime, shouldOutputJson } from "../utils/tty";
 
 interface StatusCommandOptions {
   short?: boolean;
-  json?: boolean;
+  jsonl?: boolean;
 }
 
 interface CacheSummary {
@@ -86,8 +86,8 @@ function getCacheSummary(): CacheSummary {
 export const statusCommand = new Command("status")
   .description("Show Firewatch state information")
   .option("--short", "Compact single-line output")
-  .option("--json", "Force JSON output")
-  .option("--no-json", "Force human-readable output")
+  .option("--jsonl", "Force structured output")
+  .option("--no-jsonl", "Force human-readable output")
   .action(async (options: StatusCommandOptions) => {
     try {
       await ensureDirectories();
@@ -148,7 +148,7 @@ export const statusCommand = new Command("status")
       };
 
       if (outputJson) {
-        await writeJsonLine(payload);
+        await outputStructured(payload, "jsonl");
         return;
       }
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -42,7 +42,7 @@ import { schemaCommand } from "./commands/schema";
 import { statusCommand } from "./commands/status";
 import { validateRepoFormat } from "./repo";
 import { ensureGraphiteMetadata } from "./stack";
-import { writeJsonLine } from "./utils/json";
+import { outputStructured } from "./utils/json";
 import { resolveStates } from "./utils/states";
 import { shouldOutputJson } from "./utils/tty";
 import { outputWorklist } from "./worklist";
@@ -69,7 +69,7 @@ interface RootCommandOptions {
   limit?: number;
   offset?: number;
   summary?: boolean;
-  json?: boolean;
+  jsonl?: boolean;
   debug?: boolean;
   noColor?: boolean;
 }
@@ -422,8 +422,8 @@ program
   .option("-n, --limit <count>", "Limit number of results", Number.parseInt)
   .option("--offset <count>", "Skip first N results", Number.parseInt)
   .option("--summary", "Aggregate entries into per-PR summary")
-  .option("-j, --json", "Force JSON output")
-  .option("--no-json", "Force human-readable output")
+  .option("-j, --jsonl", "Force structured output")
+  .option("--no-jsonl", "Force human-readable output")
   .option("--debug", "Enable debug logging")
   .option("--no-color", "Disable color output")
   .addHelpText(
@@ -584,9 +584,7 @@ Examples:
         if (filtered.length === 0 && process.stderr.isTTY) {
           console.error("No entries matched the query filters.");
         }
-        for (const entry of filtered) {
-          await writeJsonLine(entry);
-        }
+        await outputStructured(filtered, "jsonl");
         return;
       }
 

--- a/apps/cli/src/stack.ts
+++ b/apps/cli/src/stack.ts
@@ -7,6 +7,8 @@ import {
   type GraphiteStack,
 } from "@outfitter/firewatch-core/plugins";
 
+import { outputStructured } from "./utils/json";
+
 interface StackGroup {
   stack_id: string;
   entries: FirewatchEntry[];
@@ -110,9 +112,7 @@ export async function outputStackedEntries(
     return false;
   }
 
-  for (const group of groups) {
-    console.log(JSON.stringify(group));
-  }
+  await outputStructured(groups, "jsonl");
 
   return true;
 }

--- a/apps/cli/src/utils/json.ts
+++ b/apps/cli/src/utils/json.ts
@@ -1,9 +1,30 @@
 import { once } from "node:events";
 
+export type OutputFormat = "jsonl" | "json";
+
 export async function writeJsonLine(value: unknown): Promise<void> {
   const serialized = JSON.stringify(value);
   const line = `${serialized ?? "null"}\n`;
   if (!process.stdout.write(line)) {
     await once(process.stdout, "drain");
+  }
+}
+
+export async function outputStructured(
+  value: unknown,
+  format: OutputFormat
+): Promise<void> {
+  if (format === "json") {
+    const serialized = JSON.stringify(value, null, 2);
+    const line = `${serialized ?? "null"}\n`;
+    if (!process.stdout.write(line)) {
+      await once(process.stdout, "drain");
+    }
+    return;
+  }
+
+  const items = Array.isArray(value) ? value : [value];
+  for (const item of items) {
+    await writeJsonLine(item);
   }
 }

--- a/apps/cli/src/utils/tty.ts
+++ b/apps/cli/src/utils/tty.ts
@@ -1,30 +1,37 @@
 /**
  * TTY detection and output mode utilities
  *
- * Determines output format (JSON vs human-readable) based on:
- * 1. Explicit --json/--no-json flags
- * 2. FIREWATCH_JSON environment variable
+ * Determines output format (structured vs human-readable) based on:
+ * 1. Explicit --jsonl/--no-jsonl flags
+ * 2. FIREWATCH_JSONL (preferred) or FIREWATCH_JSON environment variable
  * 3. TTY detection (non-TTY defaults to JSON for piping)
  */
 
 export interface OutputModeOptions {
+  jsonl?: boolean;
   json?: boolean;
 }
 
 /**
- * Determine if output should be JSON based on:
- * 1. --json/--no-json flags (explicit)
- * 2. FIREWATCH_JSON env var
+ * Determine if output should be structured based on:
+ * 1. --jsonl/--no-jsonl flags (explicit)
+ * 2. FIREWATCH_JSONL (preferred) or FIREWATCH_JSON env var
  * 3. TTY detection (non-TTY defaults to JSON)
  *
- * Note: Commander's --no-json sets options.json = false (not noJson = true)
+ * Note: Commander's --no-jsonl sets options.jsonl = false (not noJsonl = true)
  */
 export function shouldOutputJson(
   options: OutputModeOptions,
   defaultFormat?: "human" | "json"
 ): boolean {
   // Explicit flag takes precedence
-  // --json sets json=true, --no-json sets json=false
+  // --jsonl sets jsonl=true, --no-jsonl sets jsonl=false
+  if (options.jsonl === true) {
+    return true;
+  }
+  if (options.jsonl === false) {
+    return false;
+  }
   if (options.json === true) {
     return true;
   }
@@ -32,7 +39,13 @@ export function shouldOutputJson(
     return false;
   }
 
-  // Environment variable
+  // Environment variable (prefer JSONL)
+  if (process.env.FIREWATCH_JSONL === "1") {
+    return true;
+  }
+  if (process.env.FIREWATCH_JSONL === "0") {
+    return false;
+  }
   if (process.env.FIREWATCH_JSON === "1") {
     return true;
   }

--- a/apps/cli/src/worklist.ts
+++ b/apps/cli/src/worklist.ts
@@ -5,6 +5,7 @@ import {
 } from "@outfitter/firewatch-core";
 
 import { ensureGraphiteMetadata } from "./stack";
+import { outputStructured } from "./utils/json";
 
 export async function outputWorklist(
   entries: FirewatchEntry[]
@@ -16,9 +17,7 @@ export async function outputWorklist(
     return false;
   }
 
-  for (const item of worklist) {
-    console.log(JSON.stringify(item));
-  }
+  await outputStructured(worklist, "jsonl");
 
   return true;
 }

--- a/apps/cli/tests/command.test.ts
+++ b/apps/cli/tests/command.test.ts
@@ -171,7 +171,7 @@ test("root command outputs filtered entries by type", async () => {
     repo,
     "--type",
     "review",
-    "--json",
+    "--jsonl",
     "--offline",
   ]);
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -28,7 +28,7 @@ The root `fw` command auto-syncs when cache data is missing or stale. Control th
 
 ### Output Format
 
-- JSONL when stdout is not a TTY or when `--json` is set
+- JSONL when stdout is not a TTY or when `--jsonl` is set
 - Human-readable output when in a TTY (configurable via `output.default_format`)
 
 ### Repo Detection

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -14,13 +14,13 @@ fw config --path             # Show config file paths
 
 ## Options
 
-| Option      | Description                               |
-| ----------- | ----------------------------------------- |
-| `--edit`    | Open config in `$EDITOR`                  |
-| `--path`    | Show config file paths                    |
-| `--local`   | Target project config (`.firewatch.toml`) |
-| `--json`    | Force JSON output                         |
-| `--no-json` | Force human-readable output               |
+| Option       | Description                               |
+| ------------ | ----------------------------------------- |
+| `--edit`     | Open config in `$EDITOR`                  |
+| `--path`     | Show config file paths                    |
+| `--local`    | Target project config (`.firewatch.toml`) |
+| `--jsonl`    | Force structured output                   |
+| `--no-jsonl` | Force human-readable output               |
 
 ## Key Format
 

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -10,10 +10,10 @@ fw doctor [options]
 
 ## Options
 
-| Option      | Description                         |
-| ----------- | ----------------------------------- |
-| `--json`    | Force JSON output                   |
-| `--no-json` | Force human-readable output         |
+| Option       | Description                         |
+| ------------ | ----------------------------------- |
+| `--jsonl`    | Force structured output             |
+| `--no-jsonl` | Force human-readable output         |
 | `--fix`     | Attempt to fix issues automatically |
 
 ## Example Output

--- a/docs/commands/fw.md
+++ b/docs/commands/fw.md
@@ -11,7 +11,7 @@ fw [options]
 ## Description
 
 - Shows actionable items when running interactively
-- Outputs JSONL when piped or when `--json` is set
+- Outputs JSONL when piped or when `--jsonl` is set
 - Auto-syncs when cache is missing or stale (configurable)
 
 ## Options
@@ -73,11 +73,11 @@ fw [options]
 
 ### Output
 
-| Option       | Description                           |
-| ------------ | ------------------------------------- |
-| `--summary`  | Aggregate entries into per-PR summary |
-| `-j, --json` | Force JSON output                     |
-| `--no-json`  | Force human-readable output           |
+| Option        | Description                           |
+| ------------- | ------------------------------------- |
+| `--summary`   | Aggregate entries into per-PR summary |
+| `-j, --jsonl` | Force structured output               |
+| `--no-jsonl`  | Force human-readable output           |
 | `--debug`    | Enable debug logging                  |
 | `--no-color` | Disable color output                  |
 
@@ -102,7 +102,7 @@ fw --reviews
 # Recent activity
 fw --since 24h
 
-# All repos, last 7 days, JSON output
+# All repos, last 7 days, JSONL output
 fw -a -s 7d -j
 
 # Per-PR summary

--- a/docs/commands/mcp.md
+++ b/docs/commands/mcp.md
@@ -14,9 +14,7 @@ The `mcp` command starts the Firewatch MCP (Model Context Protocol) server. The 
 
 ## Options
 
-| Option   | Description                                     |
-| -------- | ----------------------------------------------- |
-| `--json` | Output JSON (default, included for consistency) |
+No options.
 
 ## Examples
 

--- a/docs/commands/schema.md
+++ b/docs/commands/schema.md
@@ -11,10 +11,9 @@ fw schema <name>
 
 ## Options
 
-| Option   | Description                                         |
-| -------- | --------------------------------------------------- |
-| `name`   | Schema to display: `entry`, `worklist`, or `config` |
-| `--json` | Force JSON output                                   |
+| Option | Description                                         |
+| ------ | --------------------------------------------------- |
+| `name` | Schema to display: `entry`, `worklist`, or `config` |
 
 ## Examples
 

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -10,11 +10,11 @@ fw status [options]
 
 ## Options
 
-| Option      | Description                 |
-| ----------- | --------------------------- |
-| `--short`   | Compact single-line output  |
-| `--json`    | Force JSON output           |
-| `--no-json` | Force human-readable output |
+| Option       | Description                 |
+| ------------ | --------------------------- |
+| `--short`    | Compact single-line output  |
+| `--jsonl`    | Force structured output     |
+| `--no-jsonl` | Force human-readable output |
 
 ## Example Output (Human)
 


### PR DESCRIPTION
## Summary
    - Align output flag naming with JSONL output format.

    ## Changes
    - Replace `--json` flag with `--jsonl`.
- Update help text and references.

    ## Testing
    - Not run (not requested)