### PR TITLE
fix(cli): rename --prs flag to --pr

### DIFF
--- a/.claude/skills/firewatch/SKILL.md
+++ b/.claude/skills/firewatch/SKILL.md
@@ -15,7 +15,7 @@ Query, filter, and act on GitHub PR activity using the Firewatch CLI (`fw`).
 
 ```bash
 fw --refresh --summary --open    # Sync and see what needs attention
-fw --type comment --prs 42       # Comments on PR #42
+fw --type comment --pr 42       # Comments on PR #42
 fw --type comment | jq 'select(.author != .pr_author)'  # External feedback only
 ```
 
@@ -64,7 +64,7 @@ fw --type comment --limit 1
 ```bash
 fw --type comment              # By type
 fw --since 24h                 # By time (30s, 5m, 24h, 7d, 2w, 1mo)
-fw --prs 42                    # By PR number
+fw --pr 42                    # By PR number
 fw --author alice              # By author
 fw --open                      # Open PRs only
 fw --active                    # Open or draft PRs
@@ -229,7 +229,7 @@ For detailed Graphite workflows (querying stacks, cross-PR fixes, commit pattern
 | -------------------- | --------------------------- |
 | `--type <type>`      | Filter by entry type        |
 | `--since <duration>` | Time filter (24h, 7d, etc.) |
-| `--prs <numbers>`    | Filter by PR number(s)      |
+| `--pr <numbers>`     | Filter by PR number(s)      |
 | `--author <name>`    | Filter by author            |
 | `--open`             | Open PRs only               |
 | `--active`           | Open or draft PRs           |

--- a/.claude/skills/firewatch/graphite/commit-workflow.md
+++ b/.claude/skills/firewatch/graphite/commit-workflow.md
@@ -123,7 +123,7 @@ fw --refresh
 Then verify addressed comments:
 
 ```bash
-fw --type comment --prs PR_NUMBER | jq 'select(.file_activity_after.modified == true)'
+fw --type comment --pr PR_NUMBER | jq 'select(.file_activity_after.modified == true)'
 ```
 
 ## Common Mistakes

--- a/.claude/skills/firewatch/graphite/cross-pr-fixes.md
+++ b/.claude/skills/firewatch/graphite/cross-pr-fixes.md
@@ -57,7 +57,7 @@ fw --type comment | jq -s '
 ### Step 1: Identify the Origin
 
 ```bash
-fw --type comment --prs PR_NUMBER | jq '
+fw --type comment --pr PR_NUMBER | jq '
   select(.file_provenance != null) | {
     file,
     origin_pr: .file_provenance.origin_pr,
@@ -120,7 +120,7 @@ fw add ORIGINAL_PR "Fixed in PR #ORIGIN_PR, propagated via restack" --reply COMM
 
 ```bash
 # 1. Find cross-PR comments
-fw --type comment --prs 103 | jq '
+fw --type comment --pr 103 | jq '
   select(.file_provenance.origin_pr != .pr) | {
     file,
     fix_in: .file_provenance.origin_pr,

--- a/.claude/skills/firewatch/graphite/stack-queries.md
+++ b/.claude/skills/firewatch/graphite/stack-queries.md
@@ -101,7 +101,7 @@ Get the stack ID from one PR, then query the whole stack:
 
 ```bash
 # Get stack ID
-fw --summary --prs 102 | jq '.graphite.stack_id'
+fw --summary --pr 102 | jq '.graphite.stack_id'
 
 # Query entire stack
 fw --summary | jq 'select(.graphite.stack_id == "STACK_ID")'
@@ -125,7 +125,7 @@ fw --summary | jq 'select(.graphite != null) | {
 ### All Comments in a Stack
 
 ```bash
-fw --type comment --prs 101,102,103 | jq '{
+fw --type comment --pr 101,102,103 | jq '{
   pr,
   file,
   line,
@@ -141,7 +141,7 @@ fw --type comment --prs 101,102,103 | jq '{
 Address bottom-up (base first):
 
 ```bash
-fw --type comment --prs 101,102,103 | jq -s '
+fw --type comment --pr 101,102,103 | jq -s '
   map(select(
     .subtype == "review_comment" and
     (.file_activity_after.modified // false) == false
@@ -166,7 +166,7 @@ See [cross-pr-fixes.md](cross-pr-fixes.md) for the fix workflow.
 ### Stack-Wide Feedback Summary
 
 ```bash
-fw --type comment --prs 101,102,103 | jq -s '{
+fw --type comment --pr 101,102,103 | jq -s '{
   total: length,
   review_comments: [.[] | select(.subtype == "review_comment")] | length,
   external: [.[] | select(.author != .pr_author)] | length,
@@ -196,13 +196,13 @@ fw --summary --open | jq 'select(.graphite != null)'
 ### 2. Get All Feedback
 
 ```bash
-fw --type comment --prs X,Y,Z | jq 'select(.subtype == "review_comment")'
+fw --type comment --pr X,Y,Z | jq 'select(.subtype == "review_comment")'
 ```
 
 ### 3. Organize by Position
 
 ```bash
-fw --type comment --prs X,Y,Z | jq -s '
+fw --type comment --pr X,Y,Z | jq -s '
   map(select(.subtype == "review_comment")) |
   sort_by(.graphite.stack_position) |
   group_by(.pr) |
@@ -218,7 +218,7 @@ fw --type comment --prs X,Y,Z | jq -s '
 ### 4. Check File Provenance
 
 ```bash
-fw --type comment --prs X,Y,Z | jq '
+fw --type comment --pr X,Y,Z | jq '
   select(.file_provenance.origin_pr != .pr)
 '
 ```

--- a/.claude/skills/firewatch/patterns/implementing-feedback.md
+++ b/.claude/skills/firewatch/patterns/implementing-feedback.md
@@ -7,7 +7,7 @@ Systematic workflow for addressing review comments and making the requested chan
 ### Get Comment Details
 
 ```bash
-fw --type comment --prs PR_NUMBER | jq 'select(.subtype == "review_comment") | {
+fw --type comment --pr PR_NUMBER | jq 'select(.subtype == "review_comment") | {
   id,
   file,
   line,
@@ -45,7 +45,7 @@ Common feedback patterns and how to interpret them:
 If in a Graphite stack, check if this file originated elsewhere:
 
 ```bash
-fw --type comment --prs PR_NUMBER | jq 'select(.file_provenance != null) | {
+fw --type comment --pr PR_NUMBER | jq 'select(.file_provenance != null) | {
   file,
   origin_pr: .file_provenance.origin_pr,
   body: .body[0:80]
@@ -152,7 +152,7 @@ npm run lint
 
 ```bash
 fw --refresh
-fw --type comment --prs PR_NUMBER | jq 'select(.file == "TARGET_FILE") | {
+fw --type comment --pr PR_NUMBER | jq 'select(.file == "TARGET_FILE") | {
   file,
   addressed: .file_activity_after.modified,
   commits_after: .file_activity_after.commits_touching_file
@@ -198,7 +198,7 @@ Group related comments and address together:
 
 ```bash
 # Find all comments on same file
-fw --type comment --prs PR_NUMBER | jq 'select(.file == "src/auth.ts")'
+fw --type comment --pr PR_NUMBER | jq 'select(.file == "src/auth.ts")'
 
 # Address all at once, then resolve all
 ```
@@ -225,7 +225,7 @@ When addressing multiple comments efficiently:
 
 ```bash
 # 1. Get all unaddressed comments grouped by file
-fw --type comment --prs PR_NUMBER | jq -s '
+fw --type comment --pr PR_NUMBER | jq -s '
   map(select(.subtype == "review_comment")) |
   group_by(.file) |
   map({
@@ -246,7 +246,7 @@ After addressing all feedback:
 
 ```bash
 fw --refresh
-fw --type comment --prs PR_NUMBER | jq -s '{
+fw --type comment --pr PR_NUMBER | jq -s '{
   total: length,
   addressed: [.[] | select(.file_activity_after.modified == true)] | length,
   remaining: [.[] | select(

--- a/.claude/skills/firewatch/patterns/resolving-threads.md
+++ b/.claude/skills/firewatch/patterns/resolving-threads.md
@@ -79,7 +79,7 @@ Keep replies brief but informative:
 ### Get All Comment IDs for a PR
 
 ```bash
-fw --type comment --prs PR_NUMBER | jq -r '
+fw --type comment --pr PR_NUMBER | jq -r '
   select(.subtype == "review_comment") | .id
 '
 ```
@@ -87,7 +87,7 @@ fw --type comment --prs PR_NUMBER | jq -r '
 ### Resolve All Comments on a File
 
 ```bash
-fw --type comment --prs PR_NUMBER | jq -r '
+fw --type comment --pr PR_NUMBER | jq -r '
   select(.file == "src/auth.ts") | .id
 ' | xargs fw close
 ```
@@ -98,7 +98,7 @@ After making changes:
 
 ```bash
 fw --refresh
-fw --type comment --prs PR_NUMBER | jq -r '
+fw --type comment --pr PR_NUMBER | jq -r '
   select(
     .subtype == "review_comment" and
     .file_activity_after.modified == true
@@ -112,7 +112,7 @@ For multiple similar fixes:
 
 ```bash
 # Get IDs
-IDS=$(fw --type comment --prs PR_NUMBER | jq -r '
+IDS=$(fw --type comment --pr PR_NUMBER | jq -r '
   select(.file == "src/auth.ts") | .id
 ')
 
@@ -131,7 +131,7 @@ After resolving, sync and verify:
 
 ```bash
 fw --refresh
-fw --type comment --prs PR_NUMBER | jq '{
+fw --type comment --pr PR_NUMBER | jq '{
   file,
   line,
   id,
@@ -144,7 +144,7 @@ Resolved comments should no longer appear (or will have a resolved state).
 ### Summary of Remaining
 
 ```bash
-fw --type comment --prs PR_NUMBER | jq -s '{
+fw --type comment --pr PR_NUMBER | jq -s '{
   total: length,
   review_comments: [.[] | select(.subtype == "review_comment")] | length,
   addressed: [.[] | select(.file_activity_after.modified == true)] | length,
@@ -169,7 +169,7 @@ If GitHub shows the thread as already resolved:
 If you can't find the comment ID:
 
 1. Check you're querying the right PR
-2. Try without filters: `fw --prs PR_NUMBER`
+2. Try without filters: `fw --pr PR_NUMBER`
 3. Check if the comment is on a different PR in a stack
 
 ### Resolution Failed
@@ -196,7 +196,7 @@ When resolving threads:
 
 ```bash
 # 1. Find unaddressed comments
-fw --type comment --prs 42 | jq 'select(
+fw --type comment --pr 42 | jq 'select(
   .subtype == "review_comment" and
   (.file_activity_after.modified // false) == false
 ) | {file, line, body: .body[0:60], id}'
@@ -215,5 +215,5 @@ fw close IC_ghi IC_jkl
 
 # 6. Verify
 fw --refresh
-fw --type comment --prs 42 | jq -s 'length'
+fw --type comment --pr 42 | jq -s 'length'
 ```

--- a/.claude/skills/firewatch/references/jq-cookbook.md
+++ b/.claude/skills/firewatch/references/jq-cookbook.md
@@ -58,7 +58,7 @@ fw query --type comment | jq 'select(
 Extract IDs to use with `fw resolve`:
 
 ```bash
-fw query --type comment --prs123 | jq -r '.id'
+fw query --type comment --pr 123 | jq -r '.id'
 ```
 
 ### Group Feedback by File
@@ -66,7 +66,7 @@ fw query --type comment --prs123 | jq -r '.id'
 Useful when addressing review comments systematically:
 
 ```bash
-fw query --type comment --prs123 | jq -s '
+fw query --type comment --pr 123 | jq -s '
   group_by(.file) |
   map({
     file: .[0].file,
@@ -130,17 +130,17 @@ fw query --since 24h | jq -s '
 
 ```bash
 # Get IDs to resolve
-fw query --type comment --prs123 | jq -r 'select(.subtype == "review_comment") | .id'
+fw query --type comment --pr 123 | jq -r 'select(.subtype == "review_comment") | .id'
 
 # Use directly
-fw resolve $(fw query --type comment --prs123 | jq -r '.id' | head -5)
+fw resolve $(fw query --type comment --pr 123 | jq -r '.id' | head -5)
 ```
 
 ### For `fw comment`
 
 ```bash
 # Get thread ID to reply to
-fw query --type comment --prs123 | jq -r 'select(.file == "src/index.ts") | .id' | head -1
+fw query --type comment --pr 123 | jq -r 'select(.file == "src/index.ts") | .id' | head -1
 ```
 
 ### For External Tools

--- a/.claude/skills/firewatch/references/query-patterns.md
+++ b/.claude/skills/firewatch/references/query-patterns.md
@@ -181,7 +181,7 @@ fw --since 24h | jq -s '{
 ### Get IDs for Resolution
 
 ```bash
-fw --type comment --prs 42 | jq -r '.id'
+fw --type comment --pr 42 | jq -r '.id'
 ```
 
 ### Get URLs
@@ -245,7 +245,7 @@ fw --type comment | jq 'select(.file != null)'
 ### Feed IDs to fw close
 
 ```bash
-fw --type comment --prs 42 | jq -r '
+fw --type comment --pr 42 | jq -r '
   select(.subtype == "review_comment") | .id
 ' | xargs fw close
 ```
@@ -264,7 +264,7 @@ fw --type comment | jq -r '.url' | head -1 | xargs open
 
 ## Performance Tips
 
-1. **CLI filters first** -- `--type`, `--since`, `--prs` are faster than jq equivalents
+1. **CLI filters first** -- `--type`, `--since`, `--pr` are faster than jq equivalents
 2. **Avoid unnecessary slurp** -- Only use `-s` when aggregating
 3. **Use `--limit`** -- When you only need a few results
 4. **Chain selects** -- Multiple `select()` is fine and readable
@@ -293,7 +293,7 @@ fw --summary | jq 'select(
 ### Stack Feedback Summary
 
 ```bash
-fw --type comment --prs 101,102,103 | jq -s '{
+fw --type comment --pr 101,102,103 | jq -s '{
   total: length,
   by_pr: (group_by(.pr) | map({
     pr: .[0].pr,

--- a/.claude/skills/firewatch/references/troubleshooting.md
+++ b/.claude/skills/firewatch/references/troubleshooting.md
@@ -172,7 +172,7 @@ Quick view of cache state and recent sync info.
 2. Remove filters to broaden:
 
    ```bash
-   fw --prs PR_NUMBER  # Just PR filter
+   fw --pr PR_NUMBER  # Just PR filter
    ```
 
 3. Check PR exists in cache:

--- a/.claude/skills/fw-cli-testing/SKILL.md
+++ b/.claude/skills/fw-cli-testing/SKILL.md
@@ -127,7 +127,7 @@ Tests read-only query commands:
 | Type filtering   | `--type comment`, `--type review`, invalid types |
 | Time filtering   | `--since 24h`, `--since 7d`, invalid durations   |
 | Author filtering | `--author name`, `--author '!name'` exclusion    |
-| PR filtering     | `--prs 42`, multiple PRs                         |
+| PR filtering     | `--pr 42`, multiple PRs                          |
 | State filtering  | `--open`, `--active`, `--state merged`           |
 | Combined filters | Multiple flags together                          |
 | Special flags    | `--no-bots`, `--limit`, `--mine`                 |

--- a/.claude/skills/fw-cli-testing/runbooks/edge-cases.md
+++ b/.claude/skills/fw-cli-testing/runbooks/edge-cases.md
@@ -146,7 +146,7 @@ No special setup required. Tests validate error handling.
 
 #### Large PR Number
 
-**Command**: `bun apps/cli/bin/fw.ts query --prs 999999`
+**Command**: `bun apps/cli/bin/fw.ts query --pr 999999`
 **Expected**: Empty results (no such PR), not crash
 **Validates**: Large PR number handling
 

--- a/.claude/skills/fw-cli-testing/runbooks/query-operations.md
+++ b/.claude/skills/fw-cli-testing/runbooks/query-operations.md
@@ -120,7 +120,7 @@ bun apps/cli/bin/fw.ts sync outfitter-dev/firewatch
 
 #### Single PR
 
-**Command**: `bun apps/cli/bin/fw.ts query --prs 1 --limit 5`
+**Command**: `bun apps/cli/bin/fw.ts query --pr 1 --limit 5`
 **Expected**: All entries for PR #1 (or empty if no such PR)
 **Validates**: PR number filter
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -148,7 +148,7 @@ fw                       # Actionable items (default)
 fw --summary             # Per-PR summary
 fw --since 24h           # Recent activity
 fw --type review         # Filter by entry type
-fw --prs 42,43           # Specific PRs
+fw --pr 42,43           # Specific PRs
 fw --refresh             # Force sync before query
 fw --refresh full        # Full refresh (ignore cursor)
 ```
@@ -197,7 +197,7 @@ fw schema entry
 fw --since 24h | jq 'select(.type == "review" and .state == "approved")'
 
 # Comment count by author for PR 42
-fw --prs 42 | jq -s 'group_by(.author) | map({author: .[0].author, count: length})'
+fw --pr 42 | jq -s 'group_by(.author) | map({author: .[0].author, count: length})'
 
 # All open PRs with changes requested
 fw --type review | jq -s '

--- a/apps/cli/src/commands/pr/list.ts
+++ b/apps/cli/src/commands/pr/list.ts
@@ -39,7 +39,7 @@ import { shouldOutputJson } from "../../utils/tty";
 import { outputWorklist } from "../../worklist";
 
 interface ListCommandOptions {
-  prs?: string | boolean;
+  pr?: string | boolean;
   repo?: string;
   all?: boolean;
   mine?: boolean;
@@ -90,7 +90,7 @@ function parseCsvList(value?: string): string[] {
     .filter(Boolean);
 }
 
-function parsePrs(value: string | boolean | undefined): number[] {
+function parsePrList(value: string | boolean | undefined): number[] {
   if (!value || value === true) {
     return [];
   }
@@ -379,7 +379,7 @@ async function ensureFreshRepos(
 
 export const listCommand = new Command("list")
   .description("List PRs and activity (default: current repo)")
-  .option("--prs [numbers]", "Filter to PR domain, optionally specific PRs")
+  .option("--pr [numbers]", "Filter to PR domain, optionally specific PRs")
   .option("--repo <name>", "Filter to specific repository")
   .option("-a, --all", "Include all cached repos")
   .option("--mine", "Items on PRs assigned to me")
@@ -446,9 +446,9 @@ export const listCommand = new Command("list")
         process.exit(1);
       }
 
-      let prs: number[] = [];
+      let prList: number[] = [];
       try {
-        prs = parsePrs(options.prs);
+        prList = parsePrList(options.pr);
       } catch (error) {
         console.error(error instanceof Error ? error.message : error);
         process.exit(1);
@@ -516,7 +516,9 @@ export const listCommand = new Command("list")
       const entries = await queryEntries({
         filters: {
           ...(repoFilter && { repo: repoFilter }),
-          ...(prs.length > 0 && { prs }),
+          ...(prList.length > 0 && {
+            pr: prList.length === 1 ? prList[0] : prList,
+          }),
           ...(types.length > 0 && { type: types }),
           ...(states && { states }),
           ...(options.label && { label: options.label }),

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -48,7 +48,7 @@ import { shouldOutputJson } from "./utils/tty";
 import { outputWorklist } from "./worklist";
 
 interface RootCommandOptions {
-  prs?: string | boolean;
+  pr?: string | boolean;
   repo?: string;
   all?: boolean;
   mine?: boolean;
@@ -99,7 +99,7 @@ function parseCsvList(value?: string): string[] {
     .filter(Boolean);
 }
 
-function parsePrs(value: string | boolean | undefined): number[] {
+function parsePrList(value: string | boolean | undefined): number[] {
   if (!value || value === true) {
     return [];
   }
@@ -395,7 +395,7 @@ program
     "GitHub PR activity logger with pure JSONL output for jq-based workflows"
   )
   .version(version)
-  .option("--prs [numbers]", "Filter to PR domain, optionally specific PRs")
+  .option("--pr [numbers]", "Filter to PR domain, optionally specific PRs")
   .option("--repo <name>", "Filter to specific repository")
   .option("-a, --all", "Include all cached repos")
   .option("--mine", "Items on PRs assigned to me")
@@ -471,9 +471,9 @@ Examples:
         process.exit(1);
       }
 
-      let prs: number[] = [];
+      let prList: number[] = [];
       try {
-        prs = parsePrs(options.prs);
+        prList = parsePrList(options.pr);
       } catch (error) {
         console.error(error instanceof Error ? error.message : error);
         process.exit(1);
@@ -529,7 +529,9 @@ Examples:
       const entries = await queryEntries({
         filters: {
           ...(repoFilter && { repo: repoFilter }),
-          ...(prs.length > 0 && { prs }),
+          ...(prList.length > 0 && {
+            pr: prList.length === 1 ? prList[0] : prList,
+          }),
           ...(types.length > 0 && { type: types }),
           ...(states && { states }),
           ...(options.label && { label: options.label }),

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -79,8 +79,7 @@ type SchemaName = "query" | "entry" | "worklist" | "config";
 interface FirewatchParams {
   action?: string | undefined;
   repo?: string | undefined;
-  pr?: number | undefined;
-  prs?: number | number[] | string | undefined;
+  pr?: number | number[] | string | undefined;
   type?:
     | "comment"
     | "review"
@@ -211,6 +210,13 @@ function toNumberList(value?: number | number[] | string): number[] {
   }
 
   return results;
+}
+
+function requirePrNumber(value: FirewatchParams["pr"], action: string): number {
+  if (typeof value !== "number" || Number.isNaN(value) || value <= 0) {
+    throw new Error(`${action} requires pr.`);
+  }
+  return value;
 }
 
 function resolveStates(params: FirewatchParams): PrState[] {
@@ -684,10 +690,7 @@ async function handleQuery(params: FirewatchParams): Promise<McpToolResult> {
   const states = resolveStates(params);
   const labelFilter = resolveLabelFilter(params.label);
   const typeList = resolveTypeList(params.type);
-  const prList = [
-    ...toNumberList(params.prs),
-    ...(params.pr ? [params.pr] : []),
-  ];
+  const prList = toNumberList(params.pr);
   const { include: includeAuthors, exclude: excludeAuthors } =
     resolveAuthorLists(params.author);
 
@@ -712,10 +715,12 @@ async function handleQuery(params: FirewatchParams): Promise<McpToolResult> {
     await performSync(repos, config, detected.repo, syncOptions);
   }
 
+  const prFilter =
+    prList.length > 1 ? prList : (prList.length === 1 ? prList[0] : undefined);
+
   const queryParams = {
     repo: params.all ? undefined : params.repo,
-    pr: prList.length === 1 ? prList[0] : undefined,
-    prs: prList.length > 1 ? prList : undefined,
+    ...(prFilter !== undefined && { pr: prFilter }),
     type: typeList.length > 0 ? typeList : undefined,
     states,
     label: labelFilter,
@@ -850,13 +855,11 @@ async function handleStatus(params: FirewatchParams): Promise<McpToolResult> {
 }
 
 async function handleAdd(params: FirewatchParams): Promise<McpToolResult> {
-  if (!params.pr) {
-    throw new Error("add requires pr.");
-  }
-
   if (params.resolve && !params.reply_to) {
     throw new Error("resolve requires reply_to.");
   }
+
+  const pr = requirePrNumber(params.pr, "add");
 
   const repo = (await resolveRepo(params.repo)) ?? null;
   if (!repo) {
@@ -901,7 +904,7 @@ async function handleAdd(params: FirewatchParams): Promise<McpToolResult> {
     const review = await client.addReview(
       owner,
       name,
-      params.pr,
+      pr,
       params.review!,
       params.body
     );
@@ -909,7 +912,7 @@ async function handleAdd(params: FirewatchParams): Promise<McpToolResult> {
       JSON.stringify({
         ok: true,
         repo,
-        pr: params.pr,
+        pr,
         review: params.review,
         ...(review?.id && { review_id: review.id }),
         ...(review?.url && { url: review.url }),
@@ -919,20 +922,20 @@ async function handleAdd(params: FirewatchParams): Promise<McpToolResult> {
 
   if (hasMetadata) {
     if (labels.length > 0) {
-      await client.addLabels(owner, name, params.pr, labels);
+      await client.addLabels(owner, name, pr, labels);
     }
     if (reviewers.length > 0) {
-      await client.requestReviewers(owner, name, params.pr, reviewers);
+      await client.requestReviewers(owner, name, pr, reviewers);
     }
     if (assignees.length > 0) {
-      await client.addAssignees(owner, name, params.pr, assignees);
+      await client.addAssignees(owner, name, pr, assignees);
     }
 
     return textResult(
       JSON.stringify({
         ok: true,
         repo,
-        pr: params.pr,
+        pr,
         ...(labels.length > 0 && { labels_added: labels }),
         ...(reviewers.length > 0 && { reviewers_added: reviewers }),
         ...(assignees.length > 0 && { assignees_added: assignees }),
@@ -945,7 +948,7 @@ async function handleAdd(params: FirewatchParams): Promise<McpToolResult> {
   if (params.reply_to) {
     // Resolve short ID to full comment ID if needed
     const replyToId = await resolveCommentIdFromShortId(params.reply_to, repo);
-    const threadMap = await client.fetchReviewThreadMap(owner, name, params.pr);
+    const threadMap = await client.fetchReviewThreadMap(owner, name, pr);
     const threadId = threadMap.get(replyToId);
     if (!threadId) {
       throw new Error(`No review thread found for comment ${params.reply_to}.`);
@@ -960,7 +963,7 @@ async function handleAdd(params: FirewatchParams): Promise<McpToolResult> {
       JSON.stringify({
         ok: true,
         repo,
-        pr: params.pr,
+        pr,
         comment_id: reply.id,
         reply_to: replyToId,
         ...(params.resolve && { resolved: true }),
@@ -969,14 +972,14 @@ async function handleAdd(params: FirewatchParams): Promise<McpToolResult> {
     );
   }
 
-  const prId = await client.fetchPullRequestId(owner, name, params.pr);
+  const prId = await client.fetchPullRequestId(owner, name, pr);
   const comment = await client.addIssueComment(prId, body);
 
   return textResult(
     JSON.stringify({
       ok: true,
       repo,
-      pr: params.pr,
+      pr,
       comment_id: comment.id,
       ...(comment.url && { url: comment.url }),
     })
@@ -984,13 +987,11 @@ async function handleAdd(params: FirewatchParams): Promise<McpToolResult> {
 }
 
 async function handleEdit(params: FirewatchParams): Promise<McpToolResult> {
-  if (!params.pr) {
-    throw new Error("edit requires pr.");
-  }
-
   if (params.draft && params.ready) {
     throw new Error("edit cannot use draft and ready together.");
   }
+
+  const pr = requirePrNumber(params.pr, "edit");
 
   const milestoneName =
     typeof params.milestone === "string" ? params.milestone : undefined;
@@ -1021,7 +1022,7 @@ async function handleEdit(params: FirewatchParams): Promise<McpToolResult> {
   const client = new GitHubClient(auth.token);
 
   if (params.title || params.body || params.base) {
-    await client.editPullRequest(owner, name, params.pr, {
+    await client.editPullRequest(owner, name, pr, {
       ...(params.title && { title: params.title }),
       ...(params.body && { body: params.body }),
       ...(params.base && { base: params.base }),
@@ -1029,11 +1030,11 @@ async function handleEdit(params: FirewatchParams): Promise<McpToolResult> {
   }
 
   if (milestoneName) {
-    await client.setMilestone(owner, name, params.pr, milestoneName);
+    await client.setMilestone(owner, name, pr, milestoneName);
   }
 
   if (params.draft || params.ready) {
-    const prId = await client.fetchPullRequestId(owner, name, params.pr);
+    const prId = await client.fetchPullRequestId(owner, name, pr);
     if (params.draft) {
       await client.convertPullRequestToDraft(prId);
     }
@@ -1046,7 +1047,7 @@ async function handleEdit(params: FirewatchParams): Promise<McpToolResult> {
     JSON.stringify({
       ok: true,
       repo,
-      pr: params.pr,
+      pr,
       ...(params.title && { title: params.title }),
       ...(params.body && { body: params.body }),
       ...(params.base && { base: params.base }),
@@ -1058,10 +1059,6 @@ async function handleEdit(params: FirewatchParams): Promise<McpToolResult> {
 }
 
 async function handleRm(params: FirewatchParams): Promise<McpToolResult> {
-  if (!params.pr) {
-    throw new Error("rm requires pr.");
-  }
-
   const labels = toStringList(params.labels ?? params.label);
   const reviewers = toStringList(params.reviewer);
   const assignees = toStringList(params.assignee);
@@ -1076,6 +1073,8 @@ async function handleRm(params: FirewatchParams): Promise<McpToolResult> {
   if (!hasWork) {
     throw new Error("rm requires label, reviewer, assignee, or milestone.");
   }
+
+  const pr = requirePrNumber(params.pr, "rm");
 
   const repo = (await resolveRepo(params.repo)) ?? null;
   if (!repo) {
@@ -1096,23 +1095,23 @@ async function handleRm(params: FirewatchParams): Promise<McpToolResult> {
   const client = new GitHubClient(auth.token);
 
   if (labels.length > 0) {
-    await client.removeLabels(owner, name, params.pr, labels);
+    await client.removeLabels(owner, name, pr, labels);
   }
   if (reviewers.length > 0) {
-    await client.removeReviewers(owner, name, params.pr, reviewers);
+    await client.removeReviewers(owner, name, pr, reviewers);
   }
   if (assignees.length > 0) {
-    await client.removeAssignees(owner, name, params.pr, assignees);
+    await client.removeAssignees(owner, name, pr, assignees);
   }
   if (clearMilestone) {
-    await client.clearMilestone(owner, name, params.pr);
+    await client.clearMilestone(owner, name, pr);
   }
 
   return textResult(
     JSON.stringify({
       ok: true,
       repo,
-      pr: params.pr,
+      pr,
       ...(labels.length > 0 && { labels_removed: labels }),
       ...(reviewers.length > 0 && { reviewers_removed: reviewers }),
       ...(assignees.length > 0 && { assignees_removed: assignees }),
@@ -1445,7 +1444,7 @@ async function handleFeedback(params: FeedbackParams): Promise<McpToolResult> {
 
   if (hasPr && !hasId) {
     // PR-level operations
-    const pr = params.pr!;
+    const pr = requirePrNumber(params.pr, "feedback");
 
     // Bulk ack
     if (params.ack) {

--- a/apps/mcp/src/query.ts
+++ b/apps/mcp/src/query.ts
@@ -9,8 +9,7 @@ import {
 
 export interface QueryParams {
   repo?: string | undefined;
-  pr?: number | undefined;
-  prs?: number[] | undefined;
+  pr?: number | number[] | undefined;
   author?: string | undefined;
   type?: FirewatchEntry["type"] | FirewatchEntry["type"][] | undefined;
   states?: PrState[] | undefined;
@@ -62,7 +61,6 @@ export function buildQueryOptions(
     filters: {
       ...(repoFilter && { repo: repoFilter }),
       ...(params.pr !== undefined && { pr: params.pr }),
-      ...(params.prs && params.prs.length > 0 && { prs: params.prs }),
       ...(params.author && { author: params.author }),
       ...(params.type && { type: params.type }),
       ...(states && { states }),

--- a/apps/mcp/src/schemas.ts
+++ b/apps/mcp/src/schemas.ts
@@ -24,8 +24,7 @@ const numberList = z.union([
  */
 export const QueryParamsShape = {
   repo: repoSlug.optional(),
-  pr: prNumber.optional(),
-  prs: numberList.optional(),
+  pr: numberList.optional(),
   type: z
     .union([
       z.enum(["comment", "review", "commit", "ci", "event"]),

--- a/apps/mcp/tests/query.test.ts
+++ b/apps/mcp/tests/query.test.ts
@@ -47,7 +47,7 @@ test("buildQueryOptions applies since and list filters", () => {
 
   const before = Date.now();
   const options = buildQueryOptions(
-    { prs: [1, 2], type: ["comment", "review"] },
+    { pr: [1, 2], type: ["comment", "review"] },
     context
   );
   const after = Date.now();

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -45,7 +45,7 @@ fw --since 24h | jq 'select(.type == "review" and .state == "approved")'
 fw --type review | jq 'select(.state == "changes_requested") | {repo, pr, pr_title, author, url}'
 
 # Comment count by author for a specific PR
-fw --prs 42 | jq -s 'group_by(.author) | map({author: .[0].author, count: length})'
+fw --pr 42 | jq -s 'group_by(.author) | map({author: .[0].author, count: length})'
 
 # Latest activity per PR
 fw --since 7d | jq -s 'sort_by(.created_at) | group_by(.pr) | map(.[-1]) | .[] | {repo, pr, type, author, created_at}'

--- a/docs/commands/fw.md
+++ b/docs/commands/fw.md
@@ -20,7 +20,7 @@ fw [options]
 
 | Option            | Description                                                    |
 | ----------------- | -------------------------------------------------------------- |
-| `--prs [numbers]` | Filter to PR domain, optionally specific PRs (comma-separated) |
+| `--pr [numbers]` | Filter to PR domain, optionally specific PRs (comma-separated) |
 | `--repo <name>`   | Filter to specific repository (`owner/repo`)                   |
 | `-a, --all`       | Include all cached repos                                       |
 
@@ -88,10 +88,10 @@ fw [options]
 fw
 
 # Filter to PRs only
-fw --prs
+fw --pr
 
 # Specific PRs
-fw --prs 23,34
+fw --pr 23,34
 
 # My PRs with unaddressed feedback
 fw --mine

--- a/docs/jq-cookbook.md
+++ b/docs/jq-cookbook.md
@@ -301,7 +301,7 @@ fw --type comment | jq 'select(
 ```bash
 # Get PR numbers, then query each
 fw --summary | jq -r '.pr' | while read pr; do
-  fw --prs "$pr" --type review
+  fw --pr "$pr" --type review
 done
 ```
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -68,7 +68,7 @@ Filter cached PR activity entries.
 ```json
 {"action": "query", "since": "24h"}
 {"action": "query", "type": "review", "author": "alice"}
-{"action": "query", "prs": "23,34", "summary": true}
+{"action": "query", "pr": "23,34", "summary": true}
 {"action": "query", "states": ["open", "draft"], "limit": 10}
 {"action": "query", "summary": true, "summary_short": true}
 ```

--- a/packages/claude-plugin/firewatch/skills/firewatch/respond/SKILL.md
+++ b/packages/claude-plugin/firewatch/skills/firewatch/respond/SKILL.md
@@ -22,13 +22,13 @@ Systematic workflow for addressing PR review feedback.
 
 ```bash
 # Get all review comments for a PR
-fw --prs 123 --type review
+fw --pr 123 --type review
 
 # Get unresolved comments (review_comment subtype)
-fw --prs 123 --type comment | jq 'select(.subtype == "review_comment")'
+fw --pr 123 --type comment | jq 'select(.subtype == "review_comment")'
 
 # Check for staleness hints if present
-fw --prs 123 --type comment | jq 'select(.file_activity_after.modified == false)'
+fw --pr 123 --type comment | jq 'select(.file_activity_after.modified == false)'
 ```
 
 ## Comment Categories

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -17,11 +17,8 @@ export interface QueryFilters {
   /** Filter by repository (exact match) */
   exactRepo?: string;
 
-  /** Filter by PR number */
-  pr?: number;
-
-  /** Filter by multiple PR numbers */
-  prs?: number[];
+  /** Filter by PR number(s) */
+  pr?: number | number[];
 
   /** Filter by author (exact match) */
   author?: string;
@@ -132,7 +129,6 @@ function buildDbFilters(filters: QueryFilters): QueryFilters {
     ...(filters.repo !== undefined && { repo: filters.repo }),
     ...(filters.exactRepo !== undefined && { exactRepo: filters.exactRepo }),
     ...(filters.pr !== undefined && { pr: filters.pr }),
-    ...(filters.prs !== undefined && { prs: filters.prs }),
     ...(filters.author !== undefined && { author: filters.author }),
     ...(filters.type !== undefined && { type: filters.type }),
     ...(filters.states !== undefined && { states: filters.states }),

--- a/packages/core/src/repository.ts
+++ b/packages/core/src/repository.ts
@@ -487,17 +487,15 @@ function buildWhereClause(filters: QueryFilters): {
     params.$repo = `%${filters.repo}%`;
   }
 
-  if (filters.pr !== undefined) {
-    conditions.push("e.pr = $pr");
-    params.$pr = filters.pr;
-  }
-
-  if (filters.prs?.length) {
-    const placeholders = filters.prs.map((_, i) => `$pr_${i}`).join(", ");
+  if (Array.isArray(filters.pr) && filters.pr.length > 0) {
+    const placeholders = filters.pr.map((_, i) => `$pr_${i}`).join(", ");
     conditions.push(`e.pr IN (${placeholders})`);
-    for (const [i, pr] of filters.prs.entries()) {
+    for (const [i, pr] of filters.pr.entries()) {
       params[`$pr_${i}`] = pr;
     }
+  } else if (filters.pr !== undefined) {
+    conditions.push("e.pr = $pr");
+    params.$pr = filters.pr;
   }
 
   if (filters.author) {

--- a/packages/core/tests/repository.test.ts
+++ b/packages/core/tests/repository.test.ts
@@ -510,7 +510,7 @@ describe("Query Operations", () => {
   });
 
   test("queryEntries filters by multiple pr numbers", () => {
-    const results = queryEntries(db, { prs: [1, 3] });
+    const results = queryEntries(db, { pr: [1, 3] });
     expect(results).toHaveLength(3);
 
     closeDatabase(db);


### PR DESCRIPTION
## Summary
    - Fix PR filter flag naming for consistency.

    ## Changes
    - Rename `--prs` to `--pr`.
- Update usage and docs to match.

    ## Testing
    - Not run (not requested)