### PR TITLE
fix(cli): handle partial failures in fw close

### DIFF
--- a/apps/cli/src/commands/close.ts
+++ b/apps/cli/src/commands/close.ts
@@ -22,6 +22,15 @@ interface ResolveTarget {
   commentId: string;
 }
 
+interface CloseResult {
+  ok: boolean;
+  comment_id: string;
+  repo?: string;
+  pr?: number;
+  thread_id?: string;
+  error?: string;
+}
+
 type LookupResult = { target: ResolveTarget } | { error: string };
 
 async function lookupTarget(
@@ -71,49 +80,90 @@ function groupTargets(targets: ResolveTarget[]): Map<string, ResolveTarget[]> {
 
 async function resolveTargets(
   client: GitHubClient,
-  grouped: Map<string, ResolveTarget[]>,
-  outputJson: boolean
-): Promise<boolean> {
-  let hadError = false;
+  grouped: Map<string, ResolveTarget[]>
+): Promise<CloseResult[]> {
+  const results: CloseResult[] = [];
 
   for (const group of grouped.values()) {
     const { repo, pr } = group[0]!;
     const { owner, name } = parseRepoInput(repo);
-    const threadMap = await client.fetchReviewThreadMap(owner, name, pr);
+    let threadMap: Map<string, string>;
+
+    try {
+      threadMap = await client.fetchReviewThreadMap(owner, name, pr);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      for (const target of group) {
+        results.push({
+          ok: false,
+          repo,
+          pr,
+          comment_id: target.commentId,
+          error: message,
+        });
+      }
+      continue;
+    }
+
     const resolvedThreads = new Set<string>();
+    const failedThreads = new Map<string, string>();
 
     for (const target of group) {
       const threadId = threadMap.get(target.commentId);
       if (!threadId) {
-        console.error(
-          `No review thread found for comment ${target.commentId} (repo ${repo} PR ${pr}).`
-        );
-        hadError = true;
+        results.push({
+          ok: false,
+          repo,
+          pr,
+          comment_id: target.commentId,
+          error: `No review thread found for comment ${target.commentId}.`,
+        });
+        continue;
+      }
+
+      const failedReason = failedThreads.get(threadId);
+      if (failedReason) {
+        results.push({
+          ok: false,
+          repo,
+          pr,
+          comment_id: target.commentId,
+          thread_id: threadId,
+          error: failedReason,
+        });
         continue;
       }
 
       if (!resolvedThreads.has(threadId)) {
-        await client.resolveReviewThread(threadId);
-        resolvedThreads.add(threadId);
+        try {
+          await client.resolveReviewThread(threadId);
+          resolvedThreads.add(threadId);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          failedThreads.set(threadId, message);
+          results.push({
+            ok: false,
+            repo,
+            pr,
+            comment_id: target.commentId,
+            thread_id: threadId,
+            error: message,
+          });
+          continue;
+        }
       }
 
-      const payload = {
+      results.push({
         ok: true,
         repo,
         pr,
         comment_id: target.commentId,
         thread_id: threadId,
-      };
-
-      if (outputJson) {
-        await outputStructured(payload, "jsonl");
-      } else {
-        console.log(`Resolved ${target.commentId} on ${repo}#${pr}.`);
-      }
+      });
     }
   }
 
-  return hadError;
+  return results;
 }
 
 function printDeprecationWarning(): void {
@@ -145,29 +195,76 @@ export const closeCommand = new Command("close")
       );
 
       const targets: ResolveTarget[] = [];
-      let hadLookupError = false;
+      const results: CloseResult[] = [];
 
       for (const commentId of commentIds) {
         const result = await lookupTarget(commentId, options.repo);
         if ("error" in result) {
-          console.error(result.error);
-          hadLookupError = true;
+          results.push({
+            ok: false,
+            comment_id: commentId,
+            error: result.error,
+          });
           continue;
         }
         targets.push(result.target);
       }
 
-      if (targets.length === 0) {
+      if (targets.length > 0) {
+        const client = await createClient(config);
+        const grouped = groupTargets(targets);
+        const resolved = await resolveTargets(client, grouped);
+        results.push(...resolved);
+      }
+
+      if (results.length > 0 && outputJson) {
+        for (const result of results) {
+          await outputStructured(result, "jsonl");
+        }
+      }
+
+      if (!outputJson) {
+        const successes = results.filter((result) => result.ok);
+        const failures = results.filter((result) => !result.ok);
+
+        if (successes.length > 0) {
+          const suffix = successes.length === 1 ? "" : "s";
+          console.log(`✓ Closed ${successes.length} thread${suffix}`);
+          for (const success of successes) {
+            const location =
+              success.repo && success.pr
+                ? ` (${success.repo}#${success.pr})`
+                : "";
+            console.log(`  ${success.comment_id}${location}`);
+          }
+        }
+
+        if (failures.length > 0) {
+          const suffix = failures.length === 1 ? "" : "s";
+          console.log(`✗ Failed ${failures.length} thread${suffix}:`);
+          for (const failure of failures) {
+            const location =
+              failure.repo && failure.pr
+                ? ` (${failure.repo}#${failure.pr})`
+                : "";
+            const reason = failure.error ?? "Unknown error";
+            console.log(`  ${failure.comment_id}${location}: ${reason}`);
+          }
+        }
+      }
+
+      const successCount = results.filter((result) => result.ok).length;
+      const failureCount = results.length - successCount;
+
+      if (failureCount === 0) {
+        return;
+      }
+
+      if (successCount === 0) {
         process.exit(1);
       }
 
-      const client = await createClient(config);
-      const grouped = groupTargets(targets);
-      const resolveErrors = await resolveTargets(client, grouped, outputJson);
-
-      if (hadLookupError || resolveErrors) {
-        process.exit(1);
-      }
+      process.exit(2);
     } catch (error) {
       console.error(
         "Close failed:",


### PR DESCRIPTION
## Summary
    - Allow `fw close` to continue when some threads fail.

    ## Changes
    - Track per-thread failures without aborting the entire operation.
- Return a summarized result for partial success.

    ## Testing
    - Not run (not requested)