### PR TITLE
feat(core): store comment reactions

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -71,11 +71,12 @@ The primary data structure for individual activity records.
 
 ### Metadata
 
-| Field  | Type   | Required | Description                     |
-| ------ | ------ | -------- | ------------------------------- |
-| `url`  | string | No       | GitHub URL for this activity    |
-| `file` | string | No       | File path for review comments   |
-| `line` | number | No       | Line number for review comments |
+| Field       | Type   | Required | Description                     |
+| ----------- | ------ | -------- | ------------------------------- |
+| `url`       | string | No       | GitHub URL for this activity    |
+| `file`      | string | No       | File path for review comments   |
+| `line`      | number | No       | Line number for review comments |
+| `reactions` | object | No       | Comment reactions (see below)   |
 
 ### Staleness Hints
 
@@ -102,6 +103,20 @@ Populated when staleness hints are available on comment entries:
 | `commits_touching_file` | number  | Commits touching the file (or PR-wide if unavailable) |
 | `latest_commit`         | string  | SHA of most recent relevant commit                    |
 | `latest_commit_at`      | string  | Timestamp of latest commit                            |
+
+### Comment Reactions
+
+Reactions are available on comment entries when present.
+
+```json
+{
+  "thumbs_up_by": ["alice", "bob"]
+}
+```
+
+| Field          | Type     | Description              |
+| -------------- | -------- | ------------------------ |
+| `thumbs_up_by` | string[] | Users who 👍 the comment |
 
 ### File Provenance (Graphite)
 
@@ -236,6 +251,9 @@ Aggregated per-PR summary, output by `fw --summary`.
   "url": "https://github.com/outfitter-dev/firewatch/pull/42#discussion_r123",
   "file": "src/query.ts",
   "line": 42,
+  "reactions": {
+    "thumbs_up_by": ["alice"]
+  },
   "file_activity_after": {
     "modified": true,
     "commits_touching_file": 1,

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -11,7 +11,7 @@ import { Database } from "bun:sqlite";
  * Current schema version.
  * Increment this when making schema changes and add migration logic.
  */
-export const CURRENT_SCHEMA_VERSION = 2;
+export const CURRENT_SCHEMA_VERSION = 3;
 
 /**
  * Opens a SQLite database with optimal settings for Firewatch.
@@ -110,6 +110,7 @@ CREATE TABLE IF NOT EXISTS entries (
   graphite_json TEXT,
   file_activity_json TEXT,
   file_provenance_json TEXT,
+  reactions_json TEXT,
   PRIMARY KEY (id, repo),
   FOREIGN KEY (repo, pr) REFERENCES prs(repo, number)
 );
@@ -183,6 +184,12 @@ export function migrateSchema(db: Database, targetVersion: number): void {
         "CREATE INDEX IF NOT EXISTS idx_entries_thread_resolved ON entries(thread_resolved)"
       );
       version = 2;
+    }
+
+    // Migration 2 -> 3: Add reactions_json column for comment reactions
+    if (version === 2 && targetVersion >= 3) {
+      db.exec("ALTER TABLE entries ADD COLUMN reactions_json TEXT");
+      version = 3;
     }
 
     setSchemaVersion(db, version);

--- a/packages/core/src/schema/docs.ts
+++ b/packages/core/src/schema/docs.ts
@@ -51,6 +51,13 @@ export const ENTRY_SCHEMA_DOC = {
         stack_position: { type: "number" },
       },
     },
+    reactions: {
+      type: "object",
+      optional: true,
+      fields: {
+        thumbs_up_by: { type: "string[]" },
+      },
+    },
     graphite: {
       type: "object",
       optional: true,

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -13,16 +13,24 @@ export {
 } from "./config";
 
 export {
+  CommentReactionsSchema,
   ENTRY_TYPES,
   EntryTypeSchema,
   FirewatchEntrySchema,
   GraphiteMetadataSchema,
   PrStateSchema,
   SyncMetadataSchema,
+  isCommentEntry,
+  isIssueComment,
+  isReviewComment,
   type EntryType,
   type FirewatchEntry,
   type GraphiteMetadata,
   type PrState,
+  type CommentEntry,
+  type CommentReactions,
+  type IssueCommentEntry,
+  type ReviewCommentEntry,
   type SyncMetadata,
 } from "./entry";
 

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -8,7 +8,11 @@ import {
   upsertPR,
   type PRMetadata,
 } from "./repository";
-import type { FirewatchEntry, SyncMetadata } from "./schema/entry";
+import type {
+  CommentReactions,
+  FirewatchEntry,
+  SyncMetadata,
+} from "./schema/entry";
 
 /**
  * Map GitHub PR state to Firewatch state (for entries).
@@ -79,6 +83,24 @@ function buildPrContext(repo: string, pr: PRNode): PrContext {
     pr_branch: pr.headRefName,
     ...(labels.length > 0 && { pr_labels: labels }),
   };
+}
+
+function applyCommentReactions(
+  entries: FirewatchEntry[],
+  reactionsById: Map<string, CommentReactions>
+): FirewatchEntry[] {
+  if (reactionsById.size === 0) {
+    return entries;
+  }
+
+  return entries.map((entry) => {
+    if (entry.type !== "comment") {
+      return entry;
+    }
+
+    const reactions = reactionsById.get(entry.id);
+    return reactions ? { ...entry, reactions } : entry;
+  });
 }
 
 function reviewEntries(

--- a/packages/core/tests/repository.test.ts
+++ b/packages/core/tests/repository.test.ts
@@ -275,6 +275,9 @@ describe("Entry Operations", () => {
         origin_commit: "def456",
         stack_position: 1,
       },
+      reactions: {
+        thumbs_up_by: ["alice", "bob"],
+      },
     });
 
     insertEntry(db, entry);
@@ -283,6 +286,7 @@ describe("Entry Operations", () => {
     expect(retrieved?.graphite).toEqual(entry.graphite);
     expect(retrieved?.file_activity_after).toEqual(entry.file_activity_after);
     expect(retrieved?.file_provenance).toEqual(entry.file_provenance);
+    expect(retrieved?.reactions).toEqual(entry.reactions);
 
     closeDatabase(db);
   });
@@ -293,6 +297,7 @@ describe("Entry Operations", () => {
       graphite: undefined,
       file_activity_after: undefined,
       file_provenance: undefined,
+      reactions: undefined,
     });
 
     insertEntry(db, entry);
@@ -301,6 +306,7 @@ describe("Entry Operations", () => {
     expect(retrieved?.graphite).toBeUndefined();
     expect(retrieved?.file_activity_after).toBeUndefined();
     expect(retrieved?.file_provenance).toBeUndefined();
+    expect(retrieved?.reactions).toBeUndefined();
 
     closeDatabase(db);
   });


### PR DESCRIPTION
## Summary
    - Capture and store thumbs-up reactions for comment acknowledgements.

    ## Changes
    - Fetch comment reactions during sync.
- Store reaction metadata in entries schema.

    ## Testing
    - Not run (not requested)