### PR TITLE
test(core): add parity testing module and fix CLI test isolation

### DIFF
--- a/apps/cli/tests/command.test.ts
+++ b/apps/cli/tests/command.test.ts
@@ -137,6 +137,20 @@ afterAll(async () => {
   await rm(tempRoot, { recursive: true, force: true });
 });
 
+// Compute XDG base dirs (parent of app-specific /firewatch suffix)
+const xdgCacheHome =
+  process.platform === "darwin"
+    ? join(tempRoot, "Library", "Caches")
+    : join(tempRoot, ".cache");
+const xdgConfigHome =
+  process.platform === "darwin"
+    ? join(tempRoot, "Library", "Preferences")
+    : join(tempRoot, ".config");
+const xdgDataHome =
+  process.platform === "darwin"
+    ? join(tempRoot, "Library", "Application Support")
+    : join(tempRoot, ".local", "share");
+
 async function runCli(
   args: string[]
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
@@ -146,6 +160,10 @@ async function runCli(
     env: {
       ...process.env,
       HOME: tempRoot,
+      // Override XDG variables to ensure isolation from user's environment
+      XDG_CACHE_HOME: xdgCacheHome,
+      XDG_CONFIG_HOME: xdgConfigHome,
+      XDG_DATA_HOME: xdgDataHome,
     },
     stdout: "pipe",
     stderr: "pipe",

--- a/apps/cli/tests/fb-command.test.ts
+++ b/apps/cli/tests/fb-command.test.ts
@@ -143,6 +143,20 @@ afterAll(async () => {
   await rm(tempRoot, { recursive: true, force: true });
 });
 
+// Compute XDG base dirs (parent of app-specific /firewatch suffix)
+const xdgCacheHome =
+  process.platform === "darwin"
+    ? join(tempRoot, "Library", "Caches")
+    : join(tempRoot, ".cache");
+const xdgConfigHome =
+  process.platform === "darwin"
+    ? join(tempRoot, "Library", "Preferences")
+    : join(tempRoot, ".config");
+const xdgDataHome =
+  process.platform === "darwin"
+    ? join(tempRoot, "Library", "Application Support")
+    : join(tempRoot, ".local", "share");
+
 async function runCli(
   args: string[]
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
@@ -152,6 +166,10 @@ async function runCli(
     env: {
       ...process.env,
       HOME: tempRoot,
+      // Override XDG variables to ensure isolation from user's environment
+      XDG_CACHE_HOME: xdgCacheHome,
+      XDG_CONFIG_HOME: xdgConfigHome,
+      XDG_DATA_HOME: xdgDataHome,
     },
     stdout: "pipe",
     stderr: "pipe",
@@ -174,6 +192,7 @@ describe("fw fb", () => {
     expect(stdout).toContain("--all");
     expect(stdout).toContain("--ack");
     expect(stdout).toContain("--resolve");
+    expect(stdout).toContain("--offline");
   });
 
   test("fb lists feedback with short IDs", async () => {
@@ -182,7 +201,8 @@ describe("fw fb", () => {
       "--repo",
       repo,
       "--all",
-      "--json",
+      "--jsonl",
+      "--offline",
     ]);
 
     expect(exitCode).toBe(0);
@@ -209,7 +229,8 @@ describe("fw fb", () => {
       "--repo",
       repo,
       "--all",
-      "--json",
+      "--jsonl",
+      "--offline",
     ]);
 
     expect(exitCode).toBe(0);
@@ -232,7 +253,8 @@ describe("fw fb", () => {
       "--repo",
       repo,
       "--todo",
-      "--json",
+      "--jsonl",
+      "--offline",
     ]);
 
     expect(exitCode).toBe(0);
@@ -257,7 +279,8 @@ describe("fw fb", () => {
       "--repo",
       repo,
       "--all",
-      "--no-json",
+      "--no-jsonl",
+      "--offline",
     ]);
 
     expect(exitCode).toBe(0);

--- a/apps/cli/tests/pr-commands.test.ts
+++ b/apps/cli/tests/pr-commands.test.ts
@@ -121,6 +121,20 @@ afterAll(async () => {
   await rm(tempRoot, { recursive: true, force: true });
 });
 
+// Compute XDG base dirs (parent of app-specific /firewatch suffix)
+const xdgCacheHome =
+  process.platform === "darwin"
+    ? join(tempRoot, "Library", "Caches")
+    : join(tempRoot, ".cache");
+const xdgConfigHome =
+  process.platform === "darwin"
+    ? join(tempRoot, "Library", "Preferences")
+    : join(tempRoot, ".config");
+const xdgDataHome =
+  process.platform === "darwin"
+    ? join(tempRoot, "Library", "Application Support")
+    : join(tempRoot, ".local", "share");
+
 async function runCli(
   args: string[]
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
@@ -130,6 +144,10 @@ async function runCli(
     env: {
       ...process.env,
       HOME: tempRoot,
+      // Override XDG variables to ensure isolation from user's environment
+      XDG_CACHE_HOME: xdgCacheHome,
+      XDG_CONFIG_HOME: xdgConfigHome,
+      XDG_DATA_HOME: xdgDataHome,
     },
     stdout: "pipe",
     stderr: "pipe",
@@ -166,7 +184,7 @@ describe("fw pr", () => {
       "list",
       "--repo",
       repo,
-      "--json",
+      "--jsonl",
       "--offline",
     ]);
 
@@ -209,7 +227,7 @@ describe("fw pr", () => {
       repo,
       "--type",
       "review",
-      "--json",
+      "--jsonl",
       "--offline",
     ]);
 
@@ -223,15 +241,15 @@ describe("fw pr", () => {
     expect(entry.id).toBe("review-pr-1");
   });
 
-  test("pr list filters by --prs", async () => {
+  test("pr list filters by --pr", async () => {
     const { stdout, exitCode } = await runCli([
       "pr",
       "list",
       "--repo",
       repo,
-      "--prs",
+      "--pr",
       "51",
-      "--json",
+      "--jsonl",
       "--offline",
     ]);
 

--- a/apps/cli/tests/smoke.test.ts
+++ b/apps/cli/tests/smoke.test.ts
@@ -76,6 +76,20 @@ afterAll(async () => {
   await rm(tempRoot, { recursive: true, force: true });
 });
 
+// Compute XDG base dirs (parent of app-specific /firewatch suffix)
+const xdgCacheHome =
+  process.platform === "darwin"
+    ? join(tempRoot, "Library", "Caches")
+    : join(tempRoot, ".cache");
+const xdgConfigHome =
+  process.platform === "darwin"
+    ? join(tempRoot, "Library", "Preferences")
+    : join(tempRoot, ".config");
+const xdgDataHome =
+  process.platform === "darwin"
+    ? join(tempRoot, "Library", "Application Support")
+    : join(tempRoot, ".local", "share");
+
 test("cli smoke runs root command against cached data", async () => {
   const proc = Bun.spawn({
     cmd: [
@@ -90,6 +104,10 @@ test("cli smoke runs root command against cached data", async () => {
     env: {
       ...process.env,
       HOME: tempRoot,
+      // Override XDG variables to ensure isolation from user's environment
+      XDG_CACHE_HOME: xdgCacheHome,
+      XDG_CONFIG_HOME: xdgConfigHome,
+      XDG_DATA_HOME: xdgDataHome,
     },
     stdout: "pipe",
     stderr: "pipe",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -154,6 +154,14 @@ export {
   type ResolvedId,
 } from "./short-id";
 
+// Parity
+export {
+  compareThreads,
+  formatParityResult,
+  type GitHubThreadData,
+  type ParityResult,
+} from "./parity";
+
 // Re-export schemas
 export * from "./schema";
 

--- a/packages/core/src/parity.ts
+++ b/packages/core/src/parity.ts
@@ -1,0 +1,140 @@
+/**
+ * Parity checking between GitHub API and Firewatch cache.
+ *
+ * Used to verify that Firewatch correctly captures unresolved review threads.
+ */
+
+/**
+ * Thread data from GitHub GraphQL API.
+ */
+export interface GitHubThreadData {
+  pr: number;
+  threadId: string;
+  commentId?: string;
+}
+
+/**
+ * Result of comparing GitHub and Firewatch thread data.
+ */
+export interface ParityResult {
+  repo: string;
+  ghThreadCount: number;
+  fwThreadCount: number;
+  match: boolean;
+  ghByPr: Map<number, GitHubThreadData[]>;
+  fwByPr: Map<number, string[]>;
+  missingInFw: GitHubThreadData[];
+  extraInFw: string[];
+}
+
+/**
+ * Compare GitHub and Firewatch thread data for parity.
+ *
+ * @param repo - Repository identifier (owner/name)
+ * @param ghByPr - GitHub threads grouped by PR number
+ * @param fwByPr - Firewatch comment IDs grouped by PR number
+ * @returns Comparison result with match status and discrepancies
+ */
+export function compareThreads(
+  repo: string,
+  ghByPr: Map<number, GitHubThreadData[]>,
+  fwByPr: Map<number, string[]>
+): ParityResult {
+  // Count totals
+  let ghCount = 0;
+  let fwCount = 0;
+
+  for (const threads of ghByPr.values()) {
+    ghCount += threads.length;
+  }
+  for (const ids of fwByPr.values()) {
+    fwCount += ids.length;
+  }
+
+  // Find missing entries (in GH but not in FW)
+  const missingInFw: GitHubThreadData[] = [];
+  for (const [pr, threads] of ghByPr) {
+    const fwIds = new Set(fwByPr.get(pr));
+    for (const thread of threads) {
+      // Check if comment ID exists in FW (comment IDs are what we store)
+      if (thread.commentId && !fwIds.has(thread.commentId)) {
+        missingInFw.push(thread);
+      }
+    }
+  }
+
+  // Find extra entries (in FW but not in GH)
+  const extraInFw: string[] = [];
+  const ghCommentIds = new Set<string>();
+  for (const threads of ghByPr.values()) {
+    for (const thread of threads) {
+      if (thread.commentId) {
+        ghCommentIds.add(thread.commentId);
+      }
+    }
+  }
+  for (const ids of fwByPr.values()) {
+    for (const id of ids) {
+      if (!ghCommentIds.has(id)) {
+        extraInFw.push(id);
+      }
+    }
+  }
+
+  return {
+    repo,
+    ghThreadCount: ghCount,
+    fwThreadCount: fwCount,
+    match:
+      ghCount === fwCount && missingInFw.length === 0 && extraInFw.length === 0,
+    ghByPr,
+    fwByPr,
+    missingInFw,
+    extraInFw,
+  };
+}
+
+/**
+ * Format parity result for human-readable output.
+ */
+export function formatParityResult(result: ParityResult): string {
+  const lines: string[] = [
+    `\n=== GitHub/Firewatch Parity Check: ${result.repo} ===\n`,
+    `GitHub unresolved threads:    ${result.ghThreadCount}`,
+    `Firewatch unresolved threads: ${result.fwThreadCount}`,
+    `Status: ${result.match ? "✓ MATCH" : "✗ MISMATCH"}`,
+  ];
+
+  if (!result.match) {
+    lines.push("\n--- Details ---\n");
+
+    // Show by-PR breakdown
+    lines.push("GitHub threads by PR:");
+    for (const [pr, threads] of result.ghByPr) {
+      lines.push(`  PR #${pr}: ${threads.length} unresolved`);
+    }
+
+    lines.push("\nFirewatch threads by PR:");
+    for (const [pr, ids] of result.fwByPr) {
+      lines.push(`  PR #${pr}: ${ids.length} unresolved`);
+    }
+
+    if (result.missingInFw.length > 0) {
+      lines.push("\nMissing in Firewatch (present in GitHub):");
+      for (const thread of result.missingInFw) {
+        lines.push(
+          `  PR #${thread.pr}: ${thread.commentId ?? thread.threadId}`
+        );
+      }
+    }
+
+    if (result.extraInFw.length > 0) {
+      lines.push("\nExtra in Firewatch (not in GitHub):");
+      for (const id of result.extraInFw) {
+        lines.push(`  ${id}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/packages/core/tests/parity.test.ts
+++ b/packages/core/tests/parity.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  compareThreads,
+  formatParityResult,
+  type GitHubThreadData,
+} from "../src/parity";
+
+describe("compareThreads", () => {
+  test("returns match when both sources are empty", () => {
+    const result = compareThreads("owner/repo", new Map(), new Map());
+
+    expect(result.match).toBe(true);
+    expect(result.ghThreadCount).toBe(0);
+    expect(result.fwThreadCount).toBe(0);
+    expect(result.missingInFw).toHaveLength(0);
+    expect(result.extraInFw).toHaveLength(0);
+  });
+
+  test("returns match when both sources have identical data", () => {
+    const ghByPr = new Map<number, GitHubThreadData[]>([
+      [
+        42,
+        [
+          { pr: 42, threadId: "T1", commentId: "C1" },
+          { pr: 42, threadId: "T2", commentId: "C2" },
+        ],
+      ],
+      [43, [{ pr: 43, threadId: "T3", commentId: "C3" }]],
+    ]);
+
+    const fwByPr = new Map<number, string[]>([
+      [42, ["C1", "C2"]],
+      [43, ["C3"]],
+    ]);
+
+    const result = compareThreads("owner/repo", ghByPr, fwByPr);
+
+    expect(result.match).toBe(true);
+    expect(result.ghThreadCount).toBe(3);
+    expect(result.fwThreadCount).toBe(3);
+    expect(result.missingInFw).toHaveLength(0);
+    expect(result.extraInFw).toHaveLength(0);
+  });
+
+  test("detects missing threads in Firewatch", () => {
+    const ghByPr = new Map<number, GitHubThreadData[]>([
+      [
+        42,
+        [
+          { pr: 42, threadId: "T1", commentId: "C1" },
+          { pr: 42, threadId: "T2", commentId: "C2" },
+        ],
+      ],
+    ]);
+
+    // Firewatch is missing C2
+    const fwByPr = new Map<number, string[]>([[42, ["C1"]]]);
+
+    const result = compareThreads("owner/repo", ghByPr, fwByPr);
+
+    expect(result.match).toBe(false);
+    expect(result.ghThreadCount).toBe(2);
+    expect(result.fwThreadCount).toBe(1);
+    expect(result.missingInFw).toHaveLength(1);
+    expect(result.missingInFw[0]?.commentId).toBe("C2");
+    expect(result.extraInFw).toHaveLength(0);
+  });
+
+  test("detects extra threads in Firewatch", () => {
+    const ghByPr = new Map<number, GitHubThreadData[]>([
+      [42, [{ pr: 42, threadId: "T1", commentId: "C1" }]],
+    ]);
+
+    // Firewatch has an extra entry
+    const fwByPr = new Map<number, string[]>([[42, ["C1", "C2"]]]);
+
+    const result = compareThreads("owner/repo", ghByPr, fwByPr);
+
+    expect(result.match).toBe(false);
+    expect(result.ghThreadCount).toBe(1);
+    expect(result.fwThreadCount).toBe(2);
+    expect(result.missingInFw).toHaveLength(0);
+    expect(result.extraInFw).toHaveLength(1);
+    expect(result.extraInFw[0]).toBe("C2");
+  });
+
+  test("detects both missing and extra threads", () => {
+    const ghByPr = new Map<number, GitHubThreadData[]>([
+      [42, [{ pr: 42, threadId: "T1", commentId: "C1" }]],
+      [43, [{ pr: 43, threadId: "T2", commentId: "C2" }]],
+    ]);
+
+    // Firewatch has C1 but not C2, and has extra C3
+    const fwByPr = new Map<number, string[]>([[42, ["C1", "C3"]]]);
+
+    const result = compareThreads("owner/repo", ghByPr, fwByPr);
+
+    expect(result.match).toBe(false);
+    expect(result.ghThreadCount).toBe(2);
+    expect(result.fwThreadCount).toBe(2);
+    expect(result.missingInFw).toHaveLength(1);
+    expect(result.missingInFw[0]?.commentId).toBe("C2");
+    expect(result.extraInFw).toHaveLength(1);
+    expect(result.extraInFw[0]).toBe("C3");
+  });
+
+  test("handles threads without commentId gracefully", () => {
+    const ghByPr = new Map<number, GitHubThreadData[]>([
+      [
+        42,
+        [
+          { pr: 42, threadId: "T1", commentId: "C1" },
+          { pr: 42, threadId: "T2" }, // No commentId
+        ],
+      ],
+    ]);
+
+    const fwByPr = new Map<number, string[]>([[42, ["C1"]]]);
+
+    const result = compareThreads("owner/repo", ghByPr, fwByPr);
+
+    // Thread without commentId should not be counted as missing
+    // (we can only match on commentId)
+    expect(result.match).toBe(false); // Counts don't match (2 vs 1)
+    expect(result.ghThreadCount).toBe(2);
+    expect(result.fwThreadCount).toBe(1);
+    expect(result.missingInFw).toHaveLength(0); // No commentId = can't detect as missing
+  });
+
+  test("handles disjoint PR sets", () => {
+    const ghByPr = new Map<number, GitHubThreadData[]>([
+      [42, [{ pr: 42, threadId: "T1", commentId: "C1" }]],
+    ]);
+
+    const fwByPr = new Map<number, string[]>([[43, ["C2"]]]);
+
+    const result = compareThreads("owner/repo", ghByPr, fwByPr);
+
+    expect(result.match).toBe(false);
+    expect(result.ghThreadCount).toBe(1);
+    expect(result.fwThreadCount).toBe(1);
+    expect(result.missingInFw).toHaveLength(1);
+    expect(result.missingInFw[0]?.commentId).toBe("C1");
+    expect(result.extraInFw).toHaveLength(1);
+    expect(result.extraInFw[0]).toBe("C2");
+  });
+
+  test("preserves repo in result", () => {
+    const result = compareThreads(
+      "outfitter-dev/firewatch",
+      new Map(),
+      new Map()
+    );
+
+    expect(result.repo).toBe("outfitter-dev/firewatch");
+  });
+});
+
+describe("formatParityResult", () => {
+  test("formats matching result", () => {
+    const result = compareThreads(
+      "owner/repo",
+      new Map([[42, [{ pr: 42, threadId: "T1", commentId: "C1" }]]]),
+      new Map([[42, ["C1"]]])
+    );
+
+    const output = formatParityResult(result);
+
+    expect(output).toContain("owner/repo");
+    expect(output).toContain("GitHub unresolved threads:    1");
+    expect(output).toContain("Firewatch unresolved threads: 1");
+    expect(output).toContain("✓ MATCH");
+    expect(output).not.toContain("Details");
+  });
+
+  test("formats mismatching result with details", () => {
+    const result = compareThreads(
+      "owner/repo",
+      new Map([
+        [42, [{ pr: 42, threadId: "T1", commentId: "C1" }]],
+        [43, [{ pr: 43, threadId: "T2", commentId: "C2" }]],
+      ]),
+      new Map([[42, ["C1", "C3"]]])
+    );
+
+    const output = formatParityResult(result);
+
+    expect(output).toContain("✗ MISMATCH");
+    expect(output).toContain("Details");
+    expect(output).toContain("GitHub threads by PR:");
+    expect(output).toContain("PR #42: 1 unresolved");
+    expect(output).toContain("PR #43: 1 unresolved");
+    expect(output).toContain("Firewatch threads by PR:");
+    expect(output).toContain("PR #42: 2 unresolved");
+    expect(output).toContain("Missing in Firewatch");
+    expect(output).toContain("C2");
+    expect(output).toContain("Extra in Firewatch");
+    expect(output).toContain("C3");
+  });
+
+  test("formats result with only missing entries", () => {
+    const result = compareThreads(
+      "owner/repo",
+      new Map([[42, [{ pr: 42, threadId: "T1", commentId: "C1" }]]]),
+      new Map()
+    );
+
+    const output = formatParityResult(result);
+
+    expect(output).toContain("Missing in Firewatch");
+    expect(output).not.toContain("Extra in Firewatch");
+  });
+
+  test("formats result with only extra entries", () => {
+    const result = compareThreads(
+      "owner/repo",
+      new Map(),
+      new Map([[42, ["C1"]]])
+    );
+
+    const output = formatParityResult(result);
+
+    expect(output).not.toContain("Missing in Firewatch");
+    expect(output).toContain("Extra in Firewatch");
+  });
+});

--- a/scripts/verify-gh-parity.ts
+++ b/scripts/verify-gh-parity.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env bun
+/**
+ * Verify parity between GitHub API and Firewatch for unresolved review threads.
+ *
+ * This script compares unresolved thread counts from GitHub GraphQL API
+ * with the cached data in Firewatch to detect sync discrepancies.
+ *
+ * Usage:
+ *   bun scripts/verify-gh-parity.ts [repo]
+ *
+ * Example:
+ *   bun scripts/verify-gh-parity.ts outfitter-dev/firewatch
+ */
+
+import { $ } from "bun";
+
+import {
+  compareThreads,
+  formatParityResult,
+  type GitHubThreadData,
+} from "../packages/core/src/parity";
+
+/**
+ * Fetch unresolved thread data from GitHub GraphQL API.
+ */
+async function fetchGitHubThreads(
+  repo: string
+): Promise<Map<number, GitHubThreadData[]>> {
+  const [owner, name] = repo.split("/");
+
+  const query = `
+    query {
+      repository(owner: "${owner}", name: "${name}") {
+        pullRequests(first: 50, states: OPEN) {
+          nodes {
+            number
+            reviewThreads(first: 100) {
+              nodes {
+                id
+                isResolved
+                comments(first: 1) {
+                  nodes {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const result = await $`gh api graphql -f query=${query}`.json();
+  const prs = result.data?.repository?.pullRequests?.nodes ?? [];
+
+  const byPr = new Map<number, GitHubThreadData[]>();
+
+  for (const pr of prs) {
+    const threads: GitHubThreadData[] = [];
+    for (const thread of pr.reviewThreads?.nodes ?? []) {
+      if (!thread.isResolved) {
+        threads.push({
+          pr: pr.number,
+          threadId: thread.id,
+          commentId: thread.comments?.nodes?.[0]?.id,
+        });
+      }
+    }
+    if (threads.length > 0) {
+      byPr.set(pr.number, threads);
+    }
+  }
+
+  return byPr;
+}
+
+/**
+ * Fetch unresolved thread data from Firewatch cache.
+ */
+async function fetchFirewatchThreads(
+  repo: string
+): Promise<Map<number, string[]>> {
+  // Query fw for review comments with thread_resolved=false on open PRs
+  const result =
+    await $`bun apps/cli/bin/fw.ts --type comment --open --offline --repo ${repo}`.text();
+
+  const byPr = new Map<number, string[]>();
+
+  for (const line of result.split("\n").filter(Boolean)) {
+    try {
+      const entry = JSON.parse(line);
+      if (
+        entry.subtype === "review_comment" &&
+        entry.thread_resolved === false
+      ) {
+        const list = byPr.get(entry.pr) ?? [];
+        list.push(entry.id);
+        byPr.set(entry.pr, list);
+      }
+    } catch {
+      // Skip non-JSON lines
+    }
+  }
+
+  return byPr;
+}
+
+// Main execution
+async function main() {
+  const repo = process.argv[2] ?? "outfitter-dev/firewatch";
+
+  console.log(`Checking parity for ${repo}...`);
+
+  try {
+    const [ghByPr, fwByPr] = await Promise.all([
+      fetchGitHubThreads(repo),
+      fetchFirewatchThreads(repo),
+    ]);
+
+    const result = compareThreads(repo, ghByPr, fwByPr);
+    console.log(formatParityResult(result));
+
+    process.exit(result.match ? 0 : 1);
+  } catch (error) {
+    console.error("Error:", error instanceof Error ? error.message : error);
+    process.exit(2);
+  }
+}
+
+main();


### PR DESCRIPTION
Extract GitHub parity comparison logic from verify script into
testable core module. Add comprehensive unit tests for parity
comparison including edge cases for missing/extra threads.

Also adds --offline flag to fb command for local-only operations,
fixing tests that previously required GitHub auth for read-only
queries.

Test fixes:
- Add XDG_* environment variable overrides in CLI tests for
  proper isolation from host environment
- Update deprecated flag names (--json→--jsonl, --prs→--pr)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>