### PR TITLE
feat(config): add commit_implies_read feedback config option

### DIFF
--- a/apps/cli/src/commands/close.ts
+++ b/apps/cli/src/commands/close.ts
@@ -1,0 +1,416 @@
+import {
+  GitHubClient,
+  addAcks,
+  buildAckRecords,
+  buildShortIdCache,
+  deduplicateByCommentId,
+  detectAuth,
+  detectRepo,
+  formatShortId,
+  generateShortId,
+  getAckedIds,
+  loadConfig,
+  partitionResolutions,
+  queryEntries,
+  resolveBatchIds,
+  type BatchIdResolution,
+  type FirewatchConfig,
+  type FirewatchEntry,
+} from "@outfitter/firewatch-core";
+import { Command } from "commander";
+
+import { identifyUnaddressedFeedback } from "../actionable";
+import { parseRepoInput, validateRepoFormat } from "../repo";
+import { outputStructured } from "../utils/json";
+import { shouldOutputJson } from "../utils/tty";
+
+interface CloseCommandOptions {
+  repo?: string;
+  all?: boolean;
+  yes?: boolean;
+  jsonl?: boolean;
+}
+
+interface CloseContext {
+  client: GitHubClient;
+  config: FirewatchConfig;
+  repo: string;
+  owner: string;
+  name: string;
+  outputJson: boolean;
+}
+
+async function resolveRepo(repo?: string): Promise<string> {
+  if (repo) {
+    validateRepoFormat(repo);
+    return repo;
+  }
+
+  const detected = await detectRepo();
+  if (!detected.repo) {
+    throw new Error("No repository detected. Use --repo owner/repo.");
+  }
+
+  return detected.repo;
+}
+
+async function createContext(options: CloseCommandOptions): Promise<CloseContext> {
+  const config = await loadConfig();
+  const repo = await resolveRepo(options.repo);
+  const { owner, name } = parseRepoInput(repo);
+
+  const auth = await detectAuth(config.github_token);
+  if (!auth.token) {
+    throw new Error(auth.error ?? "No GitHub token available");
+  }
+
+  const client = new GitHubClient(auth.token);
+
+  return {
+    client,
+    config,
+    repo,
+    owner,
+    name,
+    outputJson: shouldOutputJson(options, config.output?.default_format),
+  };
+}
+
+interface CloseResult {
+  shortId: string;
+  ghId: string;
+  pr: number;
+  resolved: boolean;
+  acked: boolean;
+  error?: string;
+}
+
+async function closeComment(
+  ctx: CloseContext,
+  commentId: string,
+  shortId: string,
+  pr: number,
+  subtype: string | undefined
+): Promise<CloseResult> {
+  // For review comments, resolve the thread
+  if (subtype === "review_comment") {
+    try {
+      const threadMap = await ctx.client.fetchReviewThreadMap(
+        ctx.owner,
+        ctx.name,
+        pr
+      );
+      const threadId = threadMap.get(commentId);
+
+      if (!threadId) {
+        return {
+          shortId,
+          ghId: commentId,
+          pr,
+          resolved: false,
+          acked: false,
+          error: "No review thread found",
+        };
+      }
+
+      await ctx.client.resolveReviewThread(threadId);
+      return { shortId, ghId: commentId, pr, resolved: true, acked: false };
+    } catch (error) {
+      return {
+        shortId,
+        ghId: commentId,
+        pr,
+        resolved: false,
+        acked: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  // For issue comments, just ack (can't resolve issue comments)
+  try {
+    await ctx.client.addReaction(commentId, "THUMBS_UP");
+    return { shortId, ghId: commentId, pr, resolved: false, acked: true };
+  } catch {
+    // Reaction may already exist - still count as acked
+    return { shortId, ghId: commentId, pr, resolved: false, acked: true };
+  }
+}
+
+async function closePR(ctx: CloseContext, prNum: number): Promise<void> {
+  try {
+    const prId = await ctx.client.fetchPullRequestId(ctx.owner, ctx.name, prNum);
+    await ctx.client.closePullRequest(prId);
+
+    if (ctx.outputJson) {
+      await outputStructured(
+        { ok: true, repo: ctx.repo, pr: prNum, closed: true },
+        "jsonl"
+      );
+    } else {
+      console.log(`Closed PR #${prNum}.`);
+    }
+  } catch (error) {
+    if (ctx.outputJson) {
+      await outputStructured(
+        {
+          ok: false,
+          pr: prNum,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "jsonl"
+      );
+    } else {
+      console.error(
+        `Failed to close PR #${prNum}: ${error instanceof Error ? error.message : error}`
+      );
+    }
+  }
+}
+
+function buildSuccessItems(
+  results: CloseResult[],
+  entryMap: Map<string, FirewatchEntry>
+): { entry: FirewatchEntry; reactionAdded: boolean }[] {
+  return results
+    .filter((r) => r.resolved || r.acked)
+    .map((r) => {
+      const entry = entryMap.get(r.ghId);
+      if (!entry) {
+        return null;
+      }
+      return { entry, reactionAdded: r.acked };
+    })
+    .filter((item): item is NonNullable<typeof item> => item !== null);
+}
+
+async function outputCommentResults(
+  ctx: CloseContext,
+  results: CloseResult[],
+  errors: BatchIdResolution[]
+): Promise<void> {
+  if (ctx.outputJson) {
+    for (const r of results) {
+      await outputStructured(
+        {
+          ok: !r.error,
+          repo: ctx.repo,
+          pr: r.pr,
+          id: r.shortId,
+          gh_id: r.ghId,
+          resolved: r.resolved,
+          acked: r.acked,
+          ...(r.error && { error: r.error }),
+        },
+        "jsonl"
+      );
+    }
+    for (const e of errors) {
+      await outputStructured({ ok: false, id: e.id, error: e.error }, "jsonl");
+    }
+    return;
+  }
+
+  // Human-readable output
+  const resolved = results.filter((r) => r.resolved).length;
+  const acked = results.filter((r) => r.acked && !r.resolved).length;
+  const failed = results.filter((r) => r.error).length + errors.length;
+
+  const parts: string[] = [];
+  if (resolved > 0) {
+    parts.push(`${resolved} resolved`);
+  }
+  if (acked > 0) {
+    parts.push(`${acked} acknowledged`);
+  }
+  if (failed > 0) {
+    parts.push(`${failed} failed`);
+  }
+
+  console.log(`Closed ${results.length} comments: ${parts.join(", ")}.`);
+
+  for (const e of errors) {
+    console.error(`  ${e.id}: ${e.error}`);
+  }
+}
+
+async function handleCloseComments(
+  ctx: CloseContext,
+  ids: string[]
+): Promise<void> {
+  const resolutions = await resolveBatchIds(ids, ctx.repo);
+  const { comments, prs, errors } = partitionResolutions(resolutions);
+
+  // Handle PR numbers (close PRs)
+  for (const prRes of prs) {
+    await closePR(ctx, prRes.pr!);
+  }
+
+  // Handle comment IDs
+  const uniqueComments = deduplicateByCommentId(comments);
+
+  // Get entry details for subtype detection
+  const entries = await queryEntries({
+    filters: { repo: ctx.repo, type: "comment" },
+  });
+  const entryMap = new Map(entries.map((e) => [e.id, e]));
+
+  const results: CloseResult[] = [];
+
+  for (const comment of uniqueComments) {
+    const entry = comment.entry ?? entryMap.get(comment.id);
+    if (!entry) {
+      results.push({
+        shortId: comment.shortId ?? comment.id,
+        ghId: comment.id,
+        pr: 0,
+        resolved: false,
+        acked: false,
+        error: "Entry not found",
+      });
+      continue;
+    }
+
+    const result = await closeComment(
+      ctx,
+      entry.id,
+      comment.shortId ?? formatShortId(generateShortId(entry.id, ctx.repo)),
+      entry.pr,
+      entry.subtype
+    );
+    results.push(result);
+  }
+
+  // Create ack records for resolved/acked comments
+  const successfulItems = buildSuccessItems(results, entryMap);
+
+  if (successfulItems.length > 0) {
+    const ackRecords = buildAckRecords(successfulItems, {
+      repo: ctx.repo,
+      username: ctx.config.user?.github_username,
+    });
+    await addAcks(ackRecords);
+  }
+
+  await outputCommentResults(ctx, results, errors);
+}
+
+async function handleCloseAll(
+  ctx: CloseContext,
+  autoConfirm: boolean
+): Promise<void> {
+  const entries = await queryEntries({
+    filters: { repo: ctx.repo, type: "comment" },
+  });
+
+  buildShortIdCache(entries);
+
+  const ackedIds = await getAckedIds(ctx.repo);
+  const feedbacks = identifyUnaddressedFeedback(entries, {
+    ackedIds,
+    username: ctx.config.user?.github_username,
+    commitImpliesRead: ctx.config.feedback?.commit_implies_read,
+  });
+
+  if (feedbacks.length === 0) {
+    if (ctx.outputJson) {
+      await outputStructured(
+        { ok: true, repo: ctx.repo, closed_count: 0 },
+        "jsonl"
+      );
+    } else {
+      console.log("No unaddressed feedback to close.");
+    }
+    return;
+  }
+
+  if (!autoConfirm && !ctx.outputJson) {
+    console.log(`Found ${feedbacks.length} unaddressed feedback items.`);
+    console.log("Use --yes to confirm closing all.");
+    return;
+  }
+
+  // Close all feedback
+  const entryMap = new Map(entries.map((e) => [e.id, e]));
+  const results: CloseResult[] = [];
+
+  for (const fb of feedbacks) {
+    const entry = entryMap.get(fb.comment_id);
+    if (!entry) {
+      continue;
+    }
+
+    const shortId = formatShortId(generateShortId(entry.id, ctx.repo));
+    const result = await closeComment(
+      ctx,
+      entry.id,
+      shortId,
+      entry.pr,
+      entry.subtype
+    );
+    results.push(result);
+  }
+
+  // Create ack records
+  const successfulItems = buildSuccessItems(results, entryMap);
+
+  if (successfulItems.length > 0) {
+    const ackRecords = buildAckRecords(successfulItems, {
+      repo: ctx.repo,
+      username: ctx.config.user?.github_username,
+    });
+    await addAcks(ackRecords);
+  }
+
+  const resolved = results.filter((r) => r.resolved).length;
+  const acked = results.filter((r) => r.acked && !r.resolved).length;
+
+  if (ctx.outputJson) {
+    await outputStructured(
+      {
+        ok: true,
+        repo: ctx.repo,
+        closed_count: results.length,
+        resolved_count: resolved,
+        acked_count: acked,
+      },
+      "jsonl"
+    );
+  } else {
+    console.log(
+      `Closed ${results.length} feedback items (${resolved} resolved, ${acked} acknowledged).`
+    );
+  }
+}
+
+export const closeCommand = new Command("close")
+  .description("Close feedback: resolve review threads or close PRs")
+  .argument("[ids...]", "Comment IDs (short or full) or PR numbers")
+  .option("--repo <name>", "Repository (owner/repo format)")
+  .option("--all", "Close all unaddressed feedback")
+  .option("--yes", "Auto-confirm bulk operations")
+  .option("--jsonl", "Force structured output")
+  .option("--no-jsonl", "Force human-readable output")
+  .action(async (ids: string[], options: CloseCommandOptions) => {
+    try {
+      const ctx = await createContext(options);
+
+      if (options.all) {
+        await handleCloseAll(ctx, options.yes ?? false);
+        return;
+      }
+
+      if (ids.length === 0) {
+        console.error("Provide comment/PR IDs or use --all.");
+        process.exit(1);
+      }
+
+      await handleCloseComments(ctx, ids);
+    } catch (error) {
+      console.error(
+        "Close operation failed:",
+        error instanceof Error ? error.message : error
+      );
+      process.exit(1);
+    }
+  });

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -14,7 +14,7 @@ fw doctor [options]
 | ------------ | ----------------------------------- |
 | `--jsonl`    | Force structured output             |
 | `--no-jsonl` | Force human-readable output         |
-| `--fix`     | Attempt to fix issues automatically |
+| `--fix`      | Attempt to fix issues automatically |
 
 ## Example Output
 

--- a/docs/commands/fw.md
+++ b/docs/commands/fw.md
@@ -18,11 +18,11 @@ fw [options]
 
 ### Scope
 
-| Option            | Description                                                    |
-| ----------------- | -------------------------------------------------------------- |
+| Option           | Description                                                    |
+| ---------------- | -------------------------------------------------------------- |
 | `--pr [numbers]` | Filter to PR domain, optionally specific PRs (comma-separated) |
-| `--repo <name>`   | Filter to specific repository (`owner/repo`)                   |
-| `-a, --all`       | Include all cached repos                                       |
+| `--repo <name>`  | Filter to specific repository (`owner/repo`)                   |
+| `-a, --all`      | Include all cached repos                                       |
 
 ### Perspective
 
@@ -78,8 +78,8 @@ fw [options]
 | `--summary`   | Aggregate entries into per-PR summary |
 | `-j, --jsonl` | Force structured output               |
 | `--no-jsonl`  | Force human-readable output           |
-| `--debug`    | Enable debug logging                  |
-| `--no-color` | Disable color output                  |
+| `--debug`     | Enable debug logging                  |
+| `--no-color`  | Disable color output                  |
 
 ## Examples
 

--- a/packages/core/src/batch.ts
+++ b/packages/core/src/batch.ts
@@ -1,0 +1,304 @@
+/**
+ * Batch ID resolution and processing utilities.
+ *
+ * Consolidates common patterns for multi-ID operations:
+ * - Query once, cache once, resolve all
+ * - Parallel reaction adds
+ * - Standardized ack record creation
+ */
+
+import type { AckRecord } from "./ack";
+import type { GitHubClient } from "./github";
+import { queryEntries } from "./query";
+import type { FirewatchEntry, PrState } from "./schema";
+import {
+  buildShortIdCache,
+  classifyId,
+  formatShortId,
+  generateShortId,
+  resolveShortId,
+} from "./short-id";
+
+/**
+ * Result of resolving a single ID in a batch operation.
+ */
+export interface BatchIdResolution {
+  /** Original input ID */
+  id: string;
+  /** Type of resolution */
+  type: "comment" | "pr" | "error";
+  /** Resolved entry (for comments) */
+  entry?: FirewatchEntry | undefined;
+  /** Short ID display format (for comments) */
+  shortId?: string | undefined;
+  /** PR number (for PR type) */
+  pr?: number | undefined;
+  /** Error message (for error type) */
+  error?: string | undefined;
+}
+
+/**
+ * Result of a batch processing operation.
+ */
+export interface BatchProcessResult<T> {
+  /** Successfully processed items */
+  successful: { id: string; shortId: string; result: T }[];
+  /** Failed items */
+  failed: { id: string; error: string }[];
+  /** Summary statistics */
+  stats: { total: number; succeeded: number; failed: number };
+}
+
+/**
+ * Options for batch ID resolution.
+ */
+export interface BatchResolveOptions {
+  /** Entry type to filter by (default: "comment") */
+  entryType?: "comment" | "all";
+  /** Additional entry filters */
+  filters?: {
+    pr?: number | undefined;
+    states?: PrState[] | undefined;
+  };
+}
+
+/**
+ * Resolve multiple IDs to their full context in a single operation.
+ * Queries once, builds cache once, resolves all IDs.
+ *
+ * @param ids - Array of IDs to resolve (short IDs, full IDs, or PR numbers)
+ * @param repo - Repository in owner/repo format
+ * @param options - Resolution options
+ * @returns Array of resolution results
+ */
+export async function resolveBatchIds(
+  ids: string[],
+  repo: string,
+  options: BatchResolveOptions = {}
+): Promise<BatchIdResolution[]> {
+  const { entryType = "comment", filters = {} } = options;
+
+  // Deduplicate IDs
+  const uniqueIds = [...new Set(ids)];
+
+  // Query entries once for all IDs
+  const entries = await queryEntries({
+    filters: {
+      repo,
+      ...(entryType !== "all" && { type: entryType }),
+      ...(filters.pr !== undefined && { pr: filters.pr }),
+      ...(filters.states && { states: filters.states }),
+    },
+  });
+
+  // Build short ID cache once
+  buildShortIdCache(entries);
+
+  // Resolve each ID
+  return uniqueIds.map((id) => resolveIdFromEntries(id, repo, entries));
+}
+
+/**
+ * Resolve a single ID from a pre-loaded entry set.
+ * Used internally by resolveBatchIds.
+ */
+function resolveIdFromEntries(
+  id: string,
+  repo: string,
+  entries: FirewatchEntry[]
+): BatchIdResolution {
+  const idType = classifyId(id);
+
+  // PR number - simple resolution
+  if (idType === "pr_number") {
+    const prNum = Number.parseInt(id, 10);
+    if (Number.isNaN(prNum) || prNum <= 0) {
+      return { id, type: "error", error: `Invalid PR number: ${id}` };
+    }
+    return { id, type: "pr", pr: prNum };
+  }
+
+  // Short ID - resolve via cache
+  if (idType === "short_id") {
+    const mapping = resolveShortId(id);
+    if (!mapping) {
+      return {
+        id,
+        type: "error",
+        error: `Short ID ${formatShortId(id)} not found in cache`,
+      };
+    }
+
+    const entry = entries.find((e) => e.id === mapping.fullId);
+    if (!entry) {
+      return {
+        id,
+        type: "error",
+        error: `Entry for ${formatShortId(id)} not in cache`,
+      };
+    }
+
+    return {
+      id,
+      type: "comment",
+      entry,
+      shortId: formatShortId(mapping.shortId),
+    };
+  }
+
+  // Full ID - find directly in entries
+  if (idType === "full_id") {
+    const entry = entries.find((e) => e.id === id);
+    if (!entry) {
+      const shortDisplay = formatShortId(generateShortId(id, repo));
+      return {
+        id,
+        type: "error",
+        error: `Comment ${shortDisplay} not found in cache`,
+      };
+    }
+
+    const shortId = formatShortId(generateShortId(entry.id, entry.repo));
+    return {
+      id,
+      type: "comment",
+      entry,
+      shortId,
+    };
+  }
+
+  return { id, type: "error", error: `Invalid ID format: ${id}` };
+}
+
+/**
+ * Result of a single reaction add operation.
+ */
+export interface ReactionResult {
+  /** Comment ID */
+  commentId: string;
+  /** Whether reaction was added */
+  reactionAdded: boolean;
+  /** Error message if failed */
+  error?: string | undefined;
+}
+
+/**
+ * Add reactions to multiple comments in parallel.
+ *
+ * @param commentIds - Array of comment IDs to react to
+ * @param client - Authenticated GitHub client
+ * @returns Array of reaction results
+ */
+export function batchAddReactions(
+  commentIds: string[],
+  client: GitHubClient
+): Promise<ReactionResult[]> {
+  return Promise.all(
+    commentIds.map(async (commentId) => {
+      try {
+        await client.addReaction(commentId, "THUMBS_UP");
+        return { commentId, reactionAdded: true };
+      } catch (error) {
+        return {
+          commentId,
+          reactionAdded: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    })
+  );
+}
+
+/**
+ * Options for building ack records.
+ */
+export interface BuildAckRecordsOptions {
+  /** Repository in owner/repo format */
+  repo: string;
+  /** Username to record as acked_by */
+  username?: string | undefined;
+}
+
+/**
+ * Build standardized ack records from resolution results.
+ *
+ * @param items - Array of resolved comments with reaction results
+ * @param options - Build options
+ * @returns Array of ack records ready for storage
+ */
+export function buildAckRecords(
+  items: {
+    entry: FirewatchEntry;
+    reactionAdded: boolean;
+  }[],
+  options: BuildAckRecordsOptions
+): AckRecord[] {
+  const { repo, username } = options;
+  const now = new Date().toISOString();
+
+  return items.map((item) => ({
+    repo,
+    pr: item.entry.pr,
+    comment_id: item.entry.id,
+    acked_at: now,
+    ...(username && { acked_by: username }),
+    reaction_added: item.reactionAdded,
+  }));
+}
+
+/**
+ * Format a comment ID as a short ID for display.
+ * Convenience function combining generateShortId + formatShortId.
+ *
+ * @param commentId - Full GitHub comment ID
+ * @param repo - Repository in owner/repo format
+ * @returns Formatted short ID (e.g., \@abc12)
+ */
+export function formatCommentId(commentId: string, repo: string): string {
+  return formatShortId(generateShortId(commentId, repo));
+}
+
+/**
+ * Partition batch resolutions by type.
+ */
+export function partitionResolutions(resolutions: BatchIdResolution[]): {
+  comments: BatchIdResolution[];
+  prs: BatchIdResolution[];
+  errors: BatchIdResolution[];
+} {
+  const comments: BatchIdResolution[] = [];
+  const prs: BatchIdResolution[] = [];
+  const errors: BatchIdResolution[] = [];
+
+  for (const resolution of resolutions) {
+    if (resolution.type === "comment") {
+      comments.push(resolution);
+    } else if (resolution.type === "pr") {
+      prs.push(resolution);
+    } else {
+      errors.push(resolution);
+    }
+  }
+
+  return { comments, prs, errors };
+}
+
+/**
+ * Deduplicate resolutions by comment ID.
+ * Different short IDs might resolve to the same comment.
+ */
+export function deduplicateByCommentId(
+  resolutions: BatchIdResolution[]
+): BatchIdResolution[] {
+  const seen = new Set<string>();
+  return resolutions.filter((r) => {
+    if (!r.entry) {
+      return true;
+    }
+    if (seen.has(r.entry.id)) {
+      return false;
+    }
+    seen.add(r.entry.id);
+    return true;
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -162,6 +162,21 @@ export {
   type ParityResult,
 } from "./parity";
 
+// Batch utilities
+export {
+  batchAddReactions,
+  buildAckRecords,
+  deduplicateByCommentId,
+  formatCommentId,
+  partitionResolutions,
+  resolveBatchIds,
+  type BatchIdResolution,
+  type BatchProcessResult,
+  type BatchResolveOptions,
+  type BuildAckRecordsOptions,
+  type ReactionResult,
+} from "./batch";
+
 // Re-export schemas
 export * from "./schema";
 

--- a/packages/core/src/schema/config.ts
+++ b/packages/core/src/schema/config.ts
@@ -25,6 +25,19 @@ export const UserConfigSchema = z.object({
 export type UserConfig = z.infer<typeof UserConfigSchema>;
 
 /**
+ * Feedback identification configuration.
+ */
+export const FeedbackConfigSchema = z.object({
+  /**
+   * Treat issue comments as addressed if the logged-in user has committed
+   * to the PR after the comment was posted. Default: false (conservative).
+   */
+  commit_implies_read: z.boolean().default(false),
+});
+
+export type FeedbackConfig = z.infer<typeof FeedbackConfigSchema>;
+
+/**
  * Sync behavior configuration.
  */
 export const SyncConfigSchema = z.object({
@@ -67,6 +80,8 @@ export const FirewatchConfigSchema = z.object({
   output: OutputConfigSchema.optional(),
   /** User-specific configuration */
   user: UserConfigSchema.optional(),
+  /** Feedback identification configuration */
+  feedback: FeedbackConfigSchema.optional(),
 });
 
 export type FirewatchConfig = z.infer<typeof FirewatchConfigSchema>;

--- a/packages/core/src/schema/entry.ts
+++ b/packages/core/src/schema/entry.ts
@@ -84,6 +84,7 @@ export const FirewatchEntrySchema = z.object({
   type: EntryTypeSchema,
   subtype: z.string().optional(),
   author: z.string(),
+  author_login: z.string().optional(), // GitHub login (when available, e.g., for linked commit authors)
   body: z.string().optional(),
   state: z.string().optional(),
 

--- a/packages/core/src/sync.ts
+++ b/packages/core/src/sync.ts
@@ -175,15 +175,23 @@ function commitEntries(
   prContext: PrContext,
   capturedAt: string
 ): FirewatchEntry[] {
-  return pr.commits.nodes.map(({ commit }) => ({
-    ...prContext,
-    id: commit.oid,
-    type: "commit",
-    author: commit.author?.name ?? commit.author?.email ?? "unknown",
-    body: commit.message,
-    created_at: commit.committedDate,
-    captured_at: capturedAt,
-  }));
+  return pr.commits.nodes.map(({ commit }) => {
+    const entry: FirewatchEntry = {
+      ...prContext,
+      id: commit.oid,
+      type: "commit",
+      author: commit.author?.name ?? commit.author?.email ?? "unknown",
+      body: commit.message,
+      created_at: commit.committedDate,
+      captured_at: capturedAt,
+    };
+    // Include GitHub login if commit author has a linked account
+    const login = commit.author?.user?.login;
+    if (login) {
+      entry.author_login = login;
+    }
+    return entry;
+  });
 }
 
 function prToEntries(


### PR DESCRIPTION
## Summary

Add opt-in configuration to treat comments as addressed if the logged-in user has committed to the PR after the comment was posted.

- Add `FeedbackConfigSchema` with `commit_implies_read` option (default: false)
- Fix thumbs-up acknowledgment to check logged-in user, not PR author
- Filter feedback to open/draft PRs only (merged/closed not actionable)
- Make `hasLaterCommit` heuristic opt-in via config

## Config usage

```toml
[feedback]
commit_implies_read = true
```

## Test plan

- [x] Unit tests verify both opt-in and opt-out behaviors
- [ ] Manual: Without config, comments remain unaddressed even after commit
- [ ] Manual: With config enabled, comments after user's commit are filtered

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>