### PR TITLE
refactor(cli): extract query helpers to shared module

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,33 +1,12 @@
 import {
-  ENTRY_TYPES,
-  GitHubClient,
-  PATHS,
-  countEntries,
-  detectAuth,
   detectRepo,
   ensureDirectories,
-  getAllSyncMeta,
   getAckedIds,
-  getDatabase,
-  getRepos,
-  getSyncMeta,
   loadConfig,
-  mergeExcludeAuthors,
-  parseDurationMs,
-  parseSince,
-  parseRepoCacheFilename,
   queryEntries,
-  syncRepo,
-  type FirewatchConfig,
   type FirewatchEntry,
 } from "@outfitter/firewatch-core";
-import {
-  getGraphiteStacks,
-  graphitePlugin,
-} from "@outfitter/firewatch-core/plugins";
 import { Command } from "commander";
-import { existsSync, readdirSync } from "node:fs";
-import ora from "ora";
 
 import { version } from "../package.json";
 import { buildActionableSummary, printActionableSummary } from "./actionable";
@@ -41,368 +20,24 @@ import { examplesCommand } from "./commands/examples";
 import { fbCommand } from "./commands/fb";
 import { mcpCommand } from "./commands/mcp";
 import { prCommand } from "./commands/pr";
+import {
+  applyGlobalOptions,
+  ensureFreshRepos,
+  parsePrList,
+  parseTypes,
+  resolveAuthorFilters,
+  resolveRepoFilter,
+  resolveReposToSync,
+  resolveSinceFilter,
+  type QueryCommandOptions,
+} from "./query-helpers";
 import { schemaCommand } from "./commands/schema";
 import { statusCommand } from "./commands/status";
-import { validateRepoFormat } from "./repo";
 import { ensureGraphiteMetadata } from "./stack";
 import { outputStructured } from "./utils/json";
 import { resolveStates } from "./utils/states";
 import { shouldOutputJson } from "./utils/tty";
 import { outputWorklist } from "./worklist";
-
-interface RootCommandOptions {
-  pr?: string | boolean;
-  repo?: string;
-  all?: boolean;
-  mine?: boolean;
-  reviews?: boolean;
-  open?: boolean;
-  closed?: boolean;
-  draft?: boolean;
-  active?: boolean;
-  orphaned?: boolean;
-  state?: string;
-  type?: string;
-  label?: string;
-  author?: string;
-  noBots?: boolean;
-  since?: string;
-  before?: string;
-  offline?: boolean;
-  refresh?: boolean | "full";
-  limit?: number;
-  offset?: number;
-  summary?: boolean;
-  jsonl?: boolean;
-  debug?: boolean;
-  noColor?: boolean;
-}
-
-const DEFAULT_STALE_THRESHOLD = "5m";
-
-function applyGlobalOptions(options: RootCommandOptions): void {
-  if (options.noColor) {
-    process.env.NO_COLOR = "1";
-  }
-  if (options.debug) {
-    process.env.FIREWATCH_DEBUG = "1";
-  }
-}
-
-function isFullRepo(value: string): boolean {
-  return /^[^/]+\/[^/]+$/.test(value);
-}
-
-function parseCsvList(value?: string): string[] {
-  if (!value) {
-    return [];
-  }
-  return value
-    .split(",")
-    .map((part) => part.trim())
-    .filter(Boolean);
-}
-
-function parsePrList(value: string | boolean | undefined): number[] {
-  if (!value || value === true) {
-    return [];
-  }
-  return value
-    .split(",")
-    .map((part) => part.trim())
-    .filter(Boolean)
-    .map((part) => {
-      const parsed = Number.parseInt(part, 10);
-      if (Number.isNaN(parsed)) {
-        throw new TypeError(`Invalid PR number: ${part}`);
-      }
-      return parsed;
-    });
-}
-
-function parseTypes(value?: string): FirewatchEntry["type"][] {
-  const types = parseCsvList(value).map((type) => type.toLowerCase());
-  if (types.length === 0) {
-    return [];
-  }
-  const invalid = types.filter((t) => !ENTRY_TYPES.includes(t as never));
-  if (invalid.length > 0) {
-    throw new Error(
-      `Invalid type(s): ${invalid.join(", ")}. Valid types: ${ENTRY_TYPES.join(", ")}`
-    );
-  }
-  return types as FirewatchEntry["type"][];
-}
-
-function parseAuthorFilters(value?: string): {
-  include: string[];
-  exclude: string[];
-} {
-  const items = parseCsvList(value);
-  const include: string[] = [];
-  const exclude: string[] = [];
-
-  for (const item of items) {
-    if (item.startsWith("!")) {
-      const trimmed = item.slice(1).trim();
-      if (trimmed) {
-        exclude.push(trimmed);
-      }
-    } else {
-      include.push(item);
-    }
-  }
-
-  return { include, exclude };
-}
-
-function resolveBotPatterns(config: FirewatchConfig): RegExp[] | undefined {
-  const patterns = config.filters?.bot_patterns ?? [];
-  if (patterns.length === 0) {
-    return undefined;
-  }
-  const compiled: RegExp[] = [];
-  for (const pattern of patterns) {
-    try {
-      compiled.push(new RegExp(pattern, "i"));
-    } catch {
-      // Ignore invalid regex patterns
-    }
-  }
-  return compiled.length > 0 ? compiled : undefined;
-}
-
-/**
- * Resolve the effective since filter.
- * Priority: explicit option > orphaned default (7d) > undefined
- */
-function resolveSinceFilter(
-  since: string | undefined,
-  orphaned: boolean | undefined
-): Date | undefined {
-  const DEFAULT_ORPHANED_SINCE = "7d";
-  if (since) {
-    return parseSince(since);
-  }
-  if (orphaned) {
-    return parseSince(DEFAULT_ORPHANED_SINCE);
-  }
-  return undefined;
-}
-
-function resolveAuthorFilters(
-  options: RootCommandOptions,
-  config: FirewatchConfig
-): {
-  includeAuthors: string[];
-  excludeAuthors?: string[];
-  excludeBots?: boolean;
-  botPatterns?: RegExp[];
-} {
-  const { include, exclude } = parseAuthorFilters(options.author);
-  const excludeBots = options.noBots || config.filters?.exclude_bots;
-  const botPatterns = resolveBotPatterns(config);
-
-  const configExclusions = config.filters?.exclude_authors ?? [];
-  const mergedExclusions =
-    excludeBots || exclude.length > 0 || configExclusions.length > 0
-      ? mergeExcludeAuthors(
-          [...configExclusions, ...exclude],
-          excludeBots ?? false
-        )
-      : undefined;
-
-  return {
-    includeAuthors: include,
-    ...(mergedExclusions && { excludeAuthors: mergedExclusions }),
-    ...(excludeBots && { excludeBots }),
-    ...(botPatterns && { botPatterns }),
-  };
-}
-
-function listCachedRepos(): string[] {
-  const repos = new Set<string>();
-
-  if (existsSync(PATHS.repos)) {
-    const files = readdirSync(PATHS.repos).filter((f) => f.endsWith(".jsonl"));
-    for (const file of files) {
-      const repo = parseRepoCacheFilename(file.replace(".jsonl", ""));
-      if (repo) {
-        repos.add(repo);
-      }
-    }
-  }
-
-  const db = getDatabase();
-  for (const repo of getRepos(db)) {
-    repos.add(repo);
-  }
-  for (const meta of getAllSyncMeta(db)) {
-    repos.add(meta.repo);
-  }
-
-  return [...repos].toSorted();
-}
-
-function resolveRepoFilter(
-  options: RootCommandOptions,
-  detectedRepo: string | null
-): string | undefined {
-  if (options.repo) {
-    validateRepoFormat(options.repo);
-    return options.repo;
-  }
-  if (options.all) {
-    return undefined;
-  }
-  return detectedRepo ?? undefined;
-}
-
-function resolveReposToSync(
-  options: RootCommandOptions,
-  config: FirewatchConfig,
-  detectedRepo: string | null
-): string[] {
-  if (options.repo && isFullRepo(options.repo)) {
-    return [options.repo];
-  }
-
-  if (options.all) {
-    if (config.repos.length > 0) {
-      return config.repos;
-    }
-    const cached = listCachedRepos();
-    if (cached.length > 0) {
-      return cached;
-    }
-  }
-
-  if (detectedRepo) {
-    return [detectedRepo];
-  }
-
-  return [];
-}
-
-function getSyncMetaMap(): Map<string, { last_sync: string }> {
-  const db = getDatabase();
-  const allMeta = getAllSyncMeta(db);
-  const map = new Map<string, { last_sync: string }>();
-  for (const entry of allMeta) {
-    map.set(entry.repo, { last_sync: entry.last_sync });
-  }
-  return map;
-}
-
-async function ensureRepoCache(
-  repo: string,
-  config: FirewatchConfig,
-  detectedRepo: string | null,
-  options: { full?: boolean } = {}
-): Promise<{ synced: boolean }> {
-  const auth = await detectAuth(config.github_token);
-  if (!auth.token) {
-    throw new Error(auth.error);
-  }
-
-  const client = new GitHubClient(auth.token);
-  const useGraphite =
-    detectedRepo === repo && (await getGraphiteStacks()) !== null;
-  const plugins = useGraphite ? [graphitePlugin] : [];
-
-  const spinner = ora({
-    text: `Syncing ${repo}...`,
-    stream: process.stderr,
-    isEnabled: process.stderr.isTTY,
-  }).start();
-
-  try {
-    const result = await syncRepo(client, repo, {
-      ...(options.full && { full: true }),
-      plugins,
-    });
-    spinner.succeed(`Synced ${repo} (${result.entriesAdded} entries)`);
-  } catch (error) {
-    spinner.fail(
-      `Sync failed: ${error instanceof Error ? error.message : error}`
-    );
-    throw error;
-  }
-
-  return { synced: true };
-}
-
-function isStale(lastSync: string | undefined, threshold: string): boolean {
-  if (!lastSync) {
-    return true;
-  }
-
-  let thresholdMs = 0;
-  try {
-    thresholdMs = parseDurationMs(threshold);
-  } catch {
-    thresholdMs = parseDurationMs(DEFAULT_STALE_THRESHOLD);
-  }
-
-  const last = new Date(lastSync).getTime();
-  return Date.now() - last > thresholdMs;
-}
-
-function hasRepoCache(repo: string): boolean {
-  const db = getDatabase();
-  const meta = getSyncMeta(db, repo);
-  return meta !== null && countEntries(db, { exactRepo: repo }) > 0;
-}
-
-async function ensureFreshRepos(
-  repos: string[],
-  options: RootCommandOptions,
-  config: FirewatchConfig,
-  detectedRepo: string | null
-): Promise<void> {
-  if (repos.length === 0) {
-    return;
-  }
-
-  if (options.offline) {
-    for (const repo of repos) {
-      if (!hasRepoCache(repo)) {
-        throw new Error(`Offline mode: no cache for ${repo}.`);
-      }
-    }
-    return;
-  }
-
-  const refresh = options.refresh;
-  const forceRefresh = Boolean(refresh);
-  const fullRefresh = refresh === "full";
-  const autoSync = config.sync?.auto_sync ?? true;
-
-  if (!autoSync && !forceRefresh) {
-    return;
-  }
-
-  const meta = getSyncMetaMap();
-  const threshold = config.sync?.stale_threshold ?? DEFAULT_STALE_THRESHOLD;
-
-  for (const repo of repos) {
-    if (!isFullRepo(repo)) {
-      continue;
-    }
-
-    const hasCache = hasRepoCache(repo);
-    const lastSync = meta.get(repo)?.last_sync;
-    const needsSync = forceRefresh || !hasCache || isStale(lastSync, threshold);
-
-    if (!needsSync) {
-      continue;
-    }
-
-    await ensureRepoCache(repo, config, detectedRepo, {
-      ...(fullRefresh && { full: true }),
-    });
-  }
-}
 
 const program = new Command();
 program.enablePositionalOptions();
@@ -454,7 +89,7 @@ Examples:
   fw --mine                       Activity on my PRs
   fw examples                     Common jq patterns (escaping tips)`
   )
-  .action(async (options: RootCommandOptions) => {
+  .action(async (options: QueryCommandOptions) => {
     applyGlobalOptions(options);
 
     try {

--- a/apps/cli/src/query-helpers.ts
+++ b/apps/cli/src/query-helpers.ts
@@ -1,0 +1,474 @@
+/**
+ * Shared query helper functions for CLI commands.
+ *
+ * These functions handle parsing, resolution, caching, and sync logic
+ * used by both the root command and pr list command.
+ */
+import {
+  ENTRY_TYPES,
+  GitHubClient,
+  PATHS,
+  countEntries,
+  detectAuth,
+  getAllSyncMeta,
+  getDatabase,
+  getRepos,
+  getSyncMeta,
+  mergeExcludeAuthors,
+  parseDurationMs,
+  parseRepoCacheFilename,
+  parseSince,
+  syncRepo,
+  type FirewatchConfig,
+  type FirewatchEntry,
+} from "@outfitter/firewatch-core";
+import {
+  getGraphiteStacks,
+  graphitePlugin,
+} from "@outfitter/firewatch-core/plugins";
+import { existsSync, readdirSync } from "node:fs";
+import ora from "ora";
+
+import { validateRepoFormat } from "./repo";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Common options shared by query commands (root and pr list).
+ */
+export interface QueryCommandOptions {
+  pr?: string | boolean;
+  repo?: string;
+  all?: boolean;
+  mine?: boolean;
+  reviews?: boolean;
+  open?: boolean;
+  closed?: boolean;
+  draft?: boolean;
+  active?: boolean;
+  orphaned?: boolean;
+  state?: string;
+  type?: string;
+  label?: string;
+  author?: string;
+  noBots?: boolean;
+  since?: string;
+  before?: string;
+  offline?: boolean;
+  refresh?: boolean | "full";
+  limit?: number;
+  offset?: number;
+  summary?: boolean;
+  jsonl?: boolean;
+  debug?: boolean;
+  noColor?: boolean;
+}
+
+/**
+ * Resolved author filter configuration.
+ */
+export interface AuthorFilters {
+  includeAuthors: string[];
+  excludeAuthors?: string[];
+  excludeBots?: boolean;
+  botPatterns?: RegExp[];
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+export const DEFAULT_STALE_THRESHOLD = "5m";
+
+// ============================================================================
+// Global Options
+// ============================================================================
+
+/**
+ * Apply global options like debug and color settings.
+ */
+export function applyGlobalOptions(options: QueryCommandOptions): void {
+  if (options.noColor) {
+    process.env.NO_COLOR = "1";
+  }
+  if (options.debug) {
+    process.env.FIREWATCH_DEBUG = "1";
+  }
+}
+
+// ============================================================================
+// Parsing Functions
+// ============================================================================
+
+/**
+ * Check if a string is a full repo format (owner/repo).
+ */
+export function isFullRepo(value: string): boolean {
+  return /^[^/]+\/[^/]+$/.test(value);
+}
+
+/**
+ * Parse a comma-separated list of strings.
+ */
+export function parseCsvList(value?: string): string[] {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Parse PR numbers from string or boolean value.
+ * Returns empty array for boolean true or undefined.
+ */
+export function parsePrList(value: string | boolean | undefined): number[] {
+  if (!value || value === true) {
+    return [];
+  }
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      const parsed = Number.parseInt(part, 10);
+      if (Number.isNaN(parsed)) {
+        throw new TypeError(`Invalid PR number: ${part}`);
+      }
+      return parsed;
+    });
+}
+
+/**
+ * Parse and validate entry types from comma-separated string.
+ */
+export function parseTypes(value?: string): FirewatchEntry["type"][] {
+  const types = parseCsvList(value).map((type) => type.toLowerCase());
+  if (types.length === 0) {
+    return [];
+  }
+  const invalid = types.filter((t) => !ENTRY_TYPES.includes(t as never));
+  if (invalid.length > 0) {
+    throw new Error(
+      `Invalid type(s): ${invalid.join(", ")}. Valid types: ${ENTRY_TYPES.join(", ")}`
+    );
+  }
+  return types as FirewatchEntry["type"][];
+}
+
+/**
+ * Parse author filters, separating includes from excludes (prefixed with !).
+ */
+export function parseAuthorFilters(value?: string): {
+  include: string[];
+  exclude: string[];
+} {
+  const items = parseCsvList(value);
+  const include: string[] = [];
+  const exclude: string[] = [];
+
+  for (const item of items) {
+    if (item.startsWith("!")) {
+      const trimmed = item.slice(1).trim();
+      if (trimmed) {
+        exclude.push(trimmed);
+      }
+    } else {
+      include.push(item);
+    }
+  }
+
+  return { include, exclude };
+}
+
+// ============================================================================
+// Resolution Functions
+// ============================================================================
+
+/**
+ * Compile bot detection patterns from config.
+ */
+export function resolveBotPatterns(
+  config: FirewatchConfig
+): RegExp[] | undefined {
+  const patterns = config.filters?.bot_patterns ?? [];
+  if (patterns.length === 0) {
+    return undefined;
+  }
+  const compiled: RegExp[] = [];
+  for (const pattern of patterns) {
+    try {
+      compiled.push(new RegExp(pattern, "i"));
+    } catch {
+      // Ignore invalid regex patterns
+    }
+  }
+  return compiled.length > 0 ? compiled : undefined;
+}
+
+/**
+ * Resolve the effective since filter.
+ * Priority: explicit option > orphaned default (7d) > undefined
+ */
+export function resolveSinceFilter(
+  since: string | undefined,
+  orphaned: boolean | undefined
+): Date | undefined {
+  const DEFAULT_ORPHANED_SINCE = "7d";
+  if (since) {
+    return parseSince(since);
+  }
+  if (orphaned) {
+    return parseSince(DEFAULT_ORPHANED_SINCE);
+  }
+  return undefined;
+}
+
+/**
+ * Resolve all author-related filters from options and config.
+ */
+export function resolveAuthorFilters(
+  options: QueryCommandOptions,
+  config: FirewatchConfig
+): AuthorFilters {
+  const { include, exclude } = parseAuthorFilters(options.author);
+  const excludeBots = options.noBots || config.filters?.exclude_bots;
+  const botPatterns = resolveBotPatterns(config);
+
+  const configExclusions = config.filters?.exclude_authors ?? [];
+  const mergedExclusions =
+    excludeBots || exclude.length > 0 || configExclusions.length > 0
+      ? mergeExcludeAuthors(
+          [...configExclusions, ...exclude],
+          excludeBots ?? false
+        )
+      : undefined;
+
+  return {
+    includeAuthors: include,
+    ...(mergedExclusions && { excludeAuthors: mergedExclusions }),
+    ...(excludeBots && { excludeBots }),
+    ...(botPatterns && { botPatterns }),
+  };
+}
+
+/**
+ * Resolve repo filter from options and detected repo.
+ */
+export function resolveRepoFilter(
+  options: QueryCommandOptions,
+  detectedRepo: string | null
+): string | undefined {
+  if (options.repo) {
+    validateRepoFormat(options.repo);
+    return options.repo;
+  }
+  if (options.all) {
+    return undefined;
+  }
+  return detectedRepo ?? undefined;
+}
+
+/**
+ * Determine which repos to sync based on options and config.
+ */
+export function resolveReposToSync(
+  options: QueryCommandOptions,
+  config: FirewatchConfig,
+  detectedRepo: string | null
+): string[] {
+  if (options.repo && isFullRepo(options.repo)) {
+    return [options.repo];
+  }
+
+  if (options.all) {
+    if (config.repos.length > 0) {
+      return config.repos;
+    }
+    const cached = listCachedRepos();
+    if (cached.length > 0) {
+      return cached;
+    }
+  }
+
+  if (detectedRepo) {
+    return [detectedRepo];
+  }
+
+  return [];
+}
+
+// ============================================================================
+// Cache Utilities
+// ============================================================================
+
+/**
+ * List all repos with cached data (from files and database).
+ */
+export function listCachedRepos(): string[] {
+  const repos = new Set<string>();
+
+  // From JSONL files
+  if (existsSync(PATHS.repos)) {
+    const files = readdirSync(PATHS.repos).filter((f) => f.endsWith(".jsonl"));
+    for (const file of files) {
+      const repo = parseRepoCacheFilename(file.replace(".jsonl", ""));
+      if (repo) {
+        repos.add(repo);
+      }
+    }
+  }
+
+  // From SQLite database
+  const db = getDatabase();
+  for (const repo of getRepos(db)) {
+    repos.add(repo);
+  }
+  for (const meta of getAllSyncMeta(db)) {
+    repos.add(meta.repo);
+  }
+
+  return [...repos].toSorted();
+}
+
+/**
+ * Get sync metadata map for all repos.
+ */
+export function getSyncMetaMap(): Map<string, { last_sync: string }> {
+  const db = getDatabase();
+  const allMeta = getAllSyncMeta(db);
+  const map = new Map<string, { last_sync: string }>();
+  for (const entry of allMeta) {
+    map.set(entry.repo, { last_sync: entry.last_sync });
+  }
+  return map;
+}
+
+/**
+ * Check if a repo has cached data.
+ */
+export function hasRepoCache(repo: string): boolean {
+  const db = getDatabase();
+  const meta = getSyncMeta(db, repo);
+  return meta !== null && countEntries(db, { exactRepo: repo }) > 0;
+}
+
+/**
+ * Check if cache is stale based on threshold duration.
+ */
+export function isStale(
+  lastSync: string | undefined,
+  threshold: string
+): boolean {
+  if (!lastSync) {
+    return true;
+  }
+
+  let thresholdMs = 0;
+  try {
+    thresholdMs = parseDurationMs(threshold);
+  } catch {
+    thresholdMs = parseDurationMs(DEFAULT_STALE_THRESHOLD);
+  }
+
+  const last = new Date(lastSync).getTime();
+  return Date.now() - last > thresholdMs;
+}
+
+/**
+ * Ensure a single repo's cache is populated, syncing if needed.
+ */
+export async function ensureRepoCache(
+  repo: string,
+  config: FirewatchConfig,
+  detectedRepo: string | null,
+  options: { full?: boolean } = {}
+): Promise<{ synced: boolean }> {
+  const auth = await detectAuth(config.github_token);
+  if (!auth.token) {
+    throw new Error(auth.error);
+  }
+
+  const client = new GitHubClient(auth.token);
+  const useGraphite =
+    detectedRepo === repo && (await getGraphiteStacks()) !== null;
+  const plugins = useGraphite ? [graphitePlugin] : [];
+
+  const spinner = ora({
+    text: `Syncing ${repo}...`,
+    stream: process.stderr,
+    isEnabled: process.stderr.isTTY,
+  }).start();
+
+  try {
+    const result = await syncRepo(client, repo, {
+      ...(options.full && { full: true }),
+      plugins,
+    });
+    spinner.succeed(`Synced ${repo} (${result.entriesAdded} entries)`);
+  } catch (error) {
+    spinner.fail(
+      `Sync failed: ${error instanceof Error ? error.message : error}`
+    );
+    throw error;
+  }
+
+  return { synced: true };
+}
+
+/**
+ * Ensure all repos in list have fresh caches, syncing as needed.
+ */
+export async function ensureFreshRepos(
+  repos: string[],
+  options: QueryCommandOptions,
+  config: FirewatchConfig,
+  detectedRepo: string | null
+): Promise<void> {
+  if (repos.length === 0) {
+    return;
+  }
+
+  if (options.offline) {
+    for (const repo of repos) {
+      if (!hasRepoCache(repo)) {
+        throw new Error(`Offline mode: no cache for ${repo}.`);
+      }
+    }
+    return;
+  }
+
+  const refresh = options.refresh;
+  const forceRefresh = Boolean(refresh);
+  const fullRefresh = refresh === "full";
+  const autoSync = config.sync?.auto_sync ?? true;
+
+  if (!autoSync && !forceRefresh) {
+    return;
+  }
+
+  const meta = getSyncMetaMap();
+  const threshold = config.sync?.stale_threshold ?? DEFAULT_STALE_THRESHOLD;
+
+  for (const repo of repos) {
+    if (!isFullRepo(repo)) {
+      continue;
+    }
+
+    const hasCache = hasRepoCache(repo);
+    const lastSync = meta.get(repo)?.last_sync;
+    const needsSync = forceRefresh || !hasCache || isStale(lastSync, threshold);
+
+    if (!needsSync) {
+      continue;
+    }
+
+    await ensureRepoCache(repo, config, detectedRepo, {
+      ...(fullRefresh && { full: true }),
+    });
+  }
+}


### PR DESCRIPTION
Move 14 duplicated helper functions from list.ts and index.ts to
apps/cli/src/query-helpers.ts:
- Parsing: parseCsvList, parsePrList, parseTypes, parseAuthorFilters
- Resolution: resolveBotPatterns, resolveSinceFilter, resolveAuthorFilters,
  resolveRepoFilter, resolveReposToSync
- Cache utilities: isFullRepo, listCachedRepos, getSyncMetaMap,
  hasRepoCache, isStale, ensureRepoCache, ensureFreshRepos
- Global options: applyGlobalOptions, DEFAULT_STALE_THRESHOLD

Eliminates ~400 lines of duplication. Complexity warnings remain
(addressed in next branch).

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>