### PR TITLE
fix(skills): update --json to --jsonl in fw commands and skills

### DIFF
--- a/.claude/commands/fw/cleanup.md
+++ b/.claude/commands/fw/cleanup.md
@@ -10,7 +10,7 @@ Systematically verify and resolve comment threads that have been addressed.
 
 ## Pre-run Context
 
-!`bun apps/cli/bin/fw.ts --type comment --open --json 2>/dev/null | jq -c 'select(.subtype == "review_comment") | {pr, file, line, author, body: .body[0:60], id}' | head -20`
+!`bun apps/cli/bin/fw.ts --type comment --open --jsonl 2>/dev/null | jq -c 'select(.subtype == "review_comment") | {pr, file, line, author, body: .body[0:60], id}' | head -20`
 
 ## Skill Context
 

--- a/.claude/commands/fw/sitrep.md
+++ b/.claude/commands/fw/sitrep.md
@@ -10,7 +10,7 @@ Situation report on PR activity. Quick scan first, then detailed check if anythi
 
 ## Pre-run Context
 
-!`bun apps/cli/bin/fw.ts --refresh --open --summary --json 2>/dev/null | jq -c '{pr, title: .pr_title, state: .pr_state, stack_pos: .graphite.stack_position, comments: .counts.comments, reviews: .counts.reviews, changes_requested: .review_states.changes_requested}'`
+!`bun apps/cli/bin/fw.ts --refresh --open --summary --jsonl 2>/dev/null | jq -c '{pr, title: .pr_title, state: .pr_state, stack_pos: .graphite.stack_position, comments: .counts.comments, reviews: .counts.reviews, changes_requested: .review_states.changes_requested}'`
 
 ## Skill Context
 
@@ -49,7 +49,7 @@ Parse the pre-run context. Produce a one-glance summary:
 If anything needs attention, query for details:
 
 ```bash
-bun apps/cli/bin/fw.ts --type comment --open --json | jq -c 'select(.author != .pr_author) | select(.subtype == "review_comment") | select(.thread_resolved == false) | {pr, file, line, author, body, id}'
+bun apps/cli/bin/fw.ts --type comment --open --jsonl | jq -c 'select(.author != .pr_author) | select(.subtype == "review_comment") | select(.thread_resolved == false) | {pr, file, line, author, body, id}'
 ```
 
 #### Comment Categorization
@@ -101,7 +101,7 @@ Group findings by PR, sorted by stack position (if applicable):
 For stack PRs, check if any comments need cross-PR fixes:
 
 ```bash
-bun apps/cli/bin/fw.ts --type comment --open --json | jq -c 'select(.file_provenance.origin_pr != .pr) | {pr, fix_in: .file_provenance.origin_pr, file}'
+bun apps/cli/bin/fw.ts --type comment --open --jsonl | jq -c 'select(.file_provenance.origin_pr != .pr) | {pr, fix_in: .file_provenance.origin_pr, file}'
 ```
 
 If found, note: "⚠️ Comment on PR #X but file originated in PR #Y — fix in #Y"

--- a/.claude/commands/fw/yolo.md
+++ b/.claude/commands/fw/yolo.md
@@ -18,7 +18,7 @@ Fix all outstanding feedback, resolve threads, commit, and submit the stack.
 
 ## Pre-run Context
 
-!`bun apps/cli/bin/fw.ts --refresh --open --summary --json 2>/dev/null | jq -c '{pr, title: .pr_title, stack_pos: .graphite.stack_position, comments: .counts.comments, changes_requested: .review_states.changes_requested}'`
+!`bun apps/cli/bin/fw.ts --refresh --open --summary --jsonl 2>/dev/null | jq -c '{pr, title: .pr_title, stack_pos: .graphite.stack_position, comments: .counts.comments, changes_requested: .review_states.changes_requested}'`
 
 ## Skill Context
 

--- a/.claude/skills/firewatch/patterns/daily-standup.md
+++ b/.claude/skills/firewatch/patterns/daily-standup.md
@@ -33,7 +33,7 @@ This shows per-PR summaries with:
 For JSON output for further processing:
 
 ```bash
-fw --summary --open --json
+fw --summary --open --jsonl
 ```
 
 ### Step 3: Prioritize by Urgency

--- a/.claude/skills/fw-cli-testing/SKILL.md
+++ b/.claude/skills/fw-cli-testing/SKILL.md
@@ -123,7 +123,7 @@ Tests read-only query commands:
 
 | Area             | Tests                                            |
 | ---------------- | ------------------------------------------------ |
-| Basic output     | `--json`, `--worklist`, JSONL validation         |
+| Basic output     | `--jsonl`, `--summary`, JSONL validation         |
 | Type filtering   | `--type comment`, `--type review`, invalid types |
 | Time filtering   | `--since 24h`, `--since 7d`, invalid durations   |
 | Author filtering | `--author name`, `--author '!name'` exclusion    |
@@ -138,7 +138,7 @@ Tests informational commands:
 
 | Area   | Tests                         |
 | ------ | ----------------------------- |
-| status | Default, `--short`, `--json`  |
+| status | Default, `--short`, `--jsonl` |
 | config | Read, `--path`, `--local`     |
 | doctor | Default, `--fix`              |
 | schema | `entry`, `worklist`, `config` |

--- a/.claude/skills/fw-cli-testing/runbooks/status-info.md
+++ b/.claude/skills/fw-cli-testing/runbooks/status-info.md
@@ -30,9 +30,9 @@ Ensure inside a git repo with firewatch configured.
 
 #### JSON Status
 
-**Command**: `bun apps/cli/bin/fw.ts status --json`
-**Expected**: Valid JSON output
-**Validates**: JSON output mode
+**Command**: `bun apps/cli/bin/fw.ts status --jsonl`
+**Expected**: Valid JSONL output
+**Validates**: JSONL output mode
 
 #### Status with Limit
 


### PR DESCRIPTION
Update CLI flag references in Claude Code skills and commands to match actual CLI implementation.

## Changes
- `--json` → `--jsonl` (CLI uses `--jsonl` or `-j`)
- `--worklist` → `--summary` (flag doesn't exist)

## Files Updated
- `.claude/commands/fw/yolo.md`
- `.claude/commands/fw/cleanup.md`
- `.claude/commands/fw/sitrep.md` (3 places)
- `.claude/skills/fw-cli-testing/runbooks/status-info.md`
- `.claude/skills/fw-cli-testing/SKILL.md`
- `.claude/skills/firewatch/patterns/daily-standup.md`

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>