### PR TITLE
chore(core): upgrade @outfitter/contracts to ^0.4.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "check": "bunx tsc --noEmit"
   },
   "dependencies": {
-    "@outfitter/contracts": "^0.1.0",
+    "@outfitter/contracts": "^0.4.1",
     "env-paths": "^3.0.0",
     "zod": "^4.3.5"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,7 +17,7 @@
     "check": "bunx tsc --noEmit"
   },
   "dependencies": {
-    "@outfitter/contracts": "^0.1.0"
+    "@outfitter/contracts": "^0.4.1"
   },
   "devDependencies": {
     "@types/bun": "^1.3.6"

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "@outfitter/contracts";
+import type { Logger, LogMetadata, LogMethod } from "@outfitter/contracts/logging";
 
 type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
 
@@ -56,7 +56,7 @@ export function createLogger(options: LoggerOptions = {}): Logger {
   function log(
     level: LogLevel,
     message: string,
-    metadata?: Record<string, unknown>
+    metadata?: Record<string, unknown>,
   ): void {
     if (silent || !shouldLog(level, minLevel)) {
       return;
@@ -74,14 +74,19 @@ export function createLogger(options: LoggerOptions = {}): Logger {
     }
   }
 
+  function method(level: LogLevel): LogMethod {
+    return ((message: string, metadata?: LogMetadata) =>
+      log(level, message, metadata)) as LogMethod;
+  }
+
   return {
-    trace: (message, metadata) => log("trace", message, metadata),
-    debug: (message, metadata) => log("debug", message, metadata),
-    info: (message, metadata) => log("info", message, metadata),
-    warn: (message, metadata) => log("warn", message, metadata),
-    error: (message, metadata) => log("error", message, metadata),
-    fatal: (message, metadata) => log("fatal", message, metadata),
-    child(childContext) {
+    trace: method("trace"),
+    debug: method("debug"),
+    info: method("info"),
+    warn: method("warn"),
+    error: method("error"),
+    fatal: method("fatal"),
+    child(childContext: LogMetadata) {
       return createLogger({
         level: minLevel,
         context: { ...context, ...childContext },


### PR DESCRIPTION
## Summary
- Bump `@outfitter/contracts` from `^0.1.0` to `^0.4.1` in core and shared
- Update `createLogger` to satisfy new `LogMethod` overloaded interface
- Foundation PR for the Outfitter stack adoption series (FIRE-3)

## Test plan
- [x] `bun install` succeeds
- [x] `bun run check` passes (lint + types)
- [x] `bun test` passes (288 tests)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades `@outfitter/contracts` from ^0.1.0 to ^0.4.1 across the core and shared packages. The logger implementation was refactored to satisfy the new `LogMethod` interface by extracting a helper method pattern and adding subpath imports (`@outfitter/contracts/logging`). 

- Updated dependency versions in `packages/core/package.json` and `packages/shared/package.json`
- Refactored `createLogger` to use a `method()` helper that wraps log calls and returns properly typed `LogMethod` instances
- Added type imports for `LogMetadata` and `LogMethod` from the contracts package
- Changed from default import to subpath import (`@outfitter/contracts/logging`)
- All tests pass (288 tests) and type checking succeeds according to PR description

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward dependency upgrades with appropriate code updates to match the new interface. The PR author verified that all tests pass (288 tests), type checking succeeds, and build completes successfully. The refactoring to the logger implementation is clean and maintains backward compatibility since the Logger interface hasn't changed from a consumer perspective.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/package.json | Upgraded `@outfitter/contracts` from ^0.1.0 to ^0.4.1 as specified in the PR description |
| packages/shared/package.json | Upgraded `@outfitter/contracts` from ^0.1.0 to ^0.4.1 consistently with core package |
| packages/shared/src/logger.ts | Refactored to use new `LogMethod` interface with subpath imports and helper method pattern |

</details>


</details>


<sub>Last reviewed commit: 0e25df7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->