### PR TITLE
feat(core): extract PR mutation handlers (approve, reject, edit)

### DIFF
--- a/packages/core/src/handlers/approve.ts
+++ b/packages/core/src/handlers/approve.ts
@@ -1,0 +1,90 @@
+/**
+ * Handler for approving a pull request.
+ *
+ * Authenticates, submits an APPROVE review on the PR, and returns the
+ * review metadata. Optionally includes a review comment body.
+ */
+
+import { AuthError, Result, ValidationError } from "@outfitter/contracts";
+
+import { detectAuth } from "../auth";
+import type { HandlerContext } from "./types";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Input parameters for the approve handler. */
+export interface ApproveInput {
+  /** PR number to approve */
+  pr: number;
+  /** Repository (owner/repo) */
+  repo: string;
+  /** Optional review comment body */
+  body?: string | undefined;
+}
+
+/** Structured output from the approve handler. */
+export interface ApproveOutput {
+  /** Review node ID */
+  id: string;
+  /** URL to the review */
+  url?: string | undefined;
+}
+
+// =============================================================================
+// Handler
+// =============================================================================
+
+/**
+ * Approve a pull request.
+ *
+ * Submits an APPROVE review via the GitHub REST API.
+ *
+ * @param input - PR number, repo, optional body
+ * @param ctx - Handler context with config, db, logger
+ * @returns Result with review ID and URL on success
+ */
+export async function approveHandler(
+  input: ApproveInput,
+  ctx: HandlerContext
+): Promise<Result<ApproveOutput, Error>> {
+  const authResult = await detectAuth(ctx.config.github_token);
+  if (authResult.isErr()) {
+    return Result.err(
+      new AuthError({ message: authResult.error.message })
+    );
+  }
+
+  const { GitHubClient } = await import("../github");
+  const client = new GitHubClient(authResult.value.token);
+
+  const parts = input.repo.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return Result.err(
+      new ValidationError({ message: `Invalid repo format: ${input.repo}` })
+    );
+  }
+  const [owner, repo] = parts;
+  const reviewResult = await client.addReview(
+    owner,
+    repo,
+    input.pr,
+    "approve",
+    input.body
+  );
+
+  if (reviewResult.isErr()) {
+    return Result.err(reviewResult.error);
+  }
+
+  const review = reviewResult.value;
+  if (!review) {
+    return Result.ok({ id: "" });
+  }
+
+  return Result.ok({
+    id: review.id,
+    ...(review.url && { url: review.url }),
+  });
+}

--- a/packages/core/src/handlers/edit.ts
+++ b/packages/core/src/handlers/edit.ts
@@ -1,0 +1,234 @@
+/**
+ * Handler for editing a pull request or comment.
+ *
+ * Polymorphic: edits PR metadata (title, body, base, labels, milestone)
+ * when given a PR number, or edits a comment body when given a comment ID.
+ */
+
+import {
+  AuthError,
+  NotFoundError,
+  Result,
+  ValidationError,
+} from "@outfitter/contracts";
+
+import { detectAuth } from "../auth";
+import type { GitHubClient } from "../github";
+import { getEntry } from "../repository";
+import { classifyId, normalizeShortId, resolveShortId } from "../short-id";
+import type { HandlerContext } from "./types";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Input parameters for the edit handler. */
+export interface EditInput {
+  /** Target ID — PR number, short ID (@abc), or comment ID */
+  id: string;
+  /** Repository (owner/repo) */
+  repo: string;
+  /** New PR title (PR edit only) */
+  title?: string | undefined;
+  /** New PR/comment body */
+  body?: string | undefined;
+  /** New base branch (PR edit only) */
+  base?: string | undefined;
+  /** Labels to add (PR edit only) */
+  addLabels?: string[] | undefined;
+  /** Labels to remove (PR edit only) */
+  removeLabels?: string[] | undefined;
+  /** Milestone name (PR edit only) */
+  milestone?: string | undefined;
+}
+
+/** Structured output from the edit handler. */
+export interface EditOutput {
+  /** What was edited */
+  type: "pr" | "comment";
+  /** Whether the edit succeeded */
+  ok: boolean;
+}
+
+// =============================================================================
+// Handler
+// =============================================================================
+
+/**
+ * Edit a pull request or comment.
+ *
+ * When the ID resolves to a PR number, edits PR metadata via the REST API.
+ * When the ID resolves to a comment, edits the comment body.
+ *
+ * @param input - Target ID, repo, and fields to update
+ * @param ctx - Handler context with config, db, logger
+ * @returns Result indicating what was edited
+ */
+export async function editHandler(
+  input: EditInput,
+  ctx: HandlerContext
+): Promise<Result<EditOutput, Error>> {
+  const authResult = await detectAuth(ctx.config.github_token);
+  if (authResult.isErr()) {
+    return Result.err(
+      new AuthError({ message: authResult.error.message })
+    );
+  }
+
+  const { GitHubClient } = await import("../github");
+  const client = new GitHubClient(authResult.value.token);
+
+  const parts = input.repo.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return Result.err(
+      new ValidationError({ message: `Invalid repo format: ${input.repo}` })
+    );
+  }
+  const [owner, repo] = parts;
+
+  // Determine if this is a PR number or a comment ID
+  const idType = classifyId(input.id);
+
+  if (idType === "pr_number") {
+    return editPr(client, owner, repo, Number(input.id), input);
+  }
+
+  // Resolve short ID to comment ID
+  let commentId = input.id;
+  if (idType === "short_id") {
+    const normalized = normalizeShortId(input.id);
+    const resolved = resolveShortId(normalized);
+    if (!resolved) {
+      return Result.err(
+        new NotFoundError({
+          message: `Could not resolve short ID: ${input.id}`,
+          resourceType: "entry",
+          resourceId: input.id,
+        })
+      );
+    }
+    commentId = resolved.fullId;
+  }
+
+  return editComment(client, owner, repo, commentId, input, ctx);
+}
+
+async function editPr(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  input: EditInput
+): Promise<Result<EditOutput, Error>> {
+  const updates: { title?: string; body?: string; base?: string } = {};
+  if (input.title) {
+    updates.title = input.title;
+  }
+  if (input.body) {
+    updates.body = input.body;
+  }
+  if (input.base) {
+    updates.base = input.base;
+  }
+
+  if (Object.keys(updates).length === 0 && !input.addLabels && !input.removeLabels && !input.milestone) {
+    return Result.err(
+      new ValidationError({ message: "No fields to update" })
+    );
+  }
+
+  if (Object.keys(updates).length > 0) {
+    const editResult = await client.editPullRequest(owner, repo, prNumber, updates);
+    if (editResult.isErr()) {
+      return Result.err(editResult.error);
+    }
+  }
+
+  // Handle labels
+  if (input.addLabels?.length) {
+    const addResult = await client.addLabels(owner, repo, prNumber, input.addLabels);
+    if (addResult.isErr()) {
+      return Result.err(addResult.error);
+    }
+  }
+  if (input.removeLabels?.length) {
+    const rmResult = await client.removeLabels(owner, repo, prNumber, input.removeLabels);
+    if (rmResult.isErr()) {
+      return Result.err(rmResult.error);
+    }
+  }
+
+  // Handle milestone
+  if (input.milestone) {
+    const msResult = await client.setMilestone(owner, repo, prNumber, input.milestone);
+    if (msResult.isErr()) {
+      return Result.err(msResult.error);
+    }
+  }
+
+  return Result.ok({ type: "pr", ok: true });
+}
+
+async function editComment(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+  commentId: string,
+  input: EditInput,
+  ctx: HandlerContext
+): Promise<Result<EditOutput, Error>> {
+  if (!input.body) {
+    return Result.err(
+      new ValidationError({ message: "Comment edit requires a body" })
+    );
+  }
+
+  // Look up the entry to find the numeric comment ID for the REST API
+  const entry = getEntry(ctx.db, commentId, `${owner}/${repo}`);
+  if (!entry) {
+    return Result.err(
+      new NotFoundError({
+        message: `Entry not found: ${commentId}`,
+        resourceType: "entry",
+        resourceId: commentId,
+      })
+    );
+  }
+
+  // Issue comments use numeric IDs from the REST API
+  // The entry.id is the GraphQL node ID; we need the REST numeric ID
+  // For now, use the GraphQL mutation approach via editIssueComment
+  // which accepts the REST numeric comment ID
+  const numericId = extractNumericId(entry.id);
+  if (!numericId) {
+    return Result.err(
+      new ValidationError({
+        message: `Cannot determine numeric ID for comment: ${entry.id}`,
+      })
+    );
+  }
+
+  const editResult = await client.editIssueComment(
+    owner,
+    repo,
+    numericId,
+    input.body
+  );
+  if (editResult.isErr()) {
+    return Result.err(editResult.error);
+  }
+
+  return Result.ok({ type: "comment", ok: true });
+}
+
+/** Extract numeric ID from various GitHub ID formats. */
+function extractNumericId(id: string): number | null {
+  // Try direct numeric
+  const num = Number(id);
+  if (!Number.isNaN(num) && num > 0) {
+    return num;
+  }
+  // Try extracting trailing number from node ID patterns
+  const match = id.match(/(\d+)$/);
+  return match ? Number(match[1]) : null;
+}

--- a/packages/core/src/handlers/index.ts
+++ b/packages/core/src/handlers/index.ts
@@ -5,6 +5,11 @@ export {
   type AckOutput,
 } from "./ack";
 export {
+  approveHandler,
+  type ApproveInput,
+  type ApproveOutput,
+} from "./approve";
+export {
   closeHandler,
   type CloseInput,
   type CloseOutput,
@@ -21,10 +26,20 @@ export {
   type DoctorOutput,
 } from "./doctor";
 export {
+  editHandler,
+  type EditInput,
+  type EditOutput,
+} from "./edit";
+export {
   queryHandler,
   type QueryInput,
   type QueryOutput,
 } from "./query";
+export {
+  rejectHandler,
+  type RejectInput,
+  type RejectOutput,
+} from "./reject";
 export {
   replyHandler,
   type ReplyInput,

--- a/packages/core/src/handlers/reject.ts
+++ b/packages/core/src/handlers/reject.ts
@@ -1,0 +1,91 @@
+/**
+ * Handler for requesting changes on a pull request.
+ *
+ * Authenticates, submits a REQUEST_CHANGES review on the PR, and returns
+ * the review metadata.
+ */
+
+import { AuthError, Result, ValidationError } from "@outfitter/contracts";
+
+import { detectAuth } from "../auth";
+import type { HandlerContext } from "./types";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Input parameters for the reject handler. */
+export interface RejectInput {
+  /** PR number to request changes on */
+  pr: number;
+  /** Repository (owner/repo) */
+  repo: string;
+  /** Review comment body (required for REQUEST_CHANGES) */
+  body: string;
+}
+
+/** Structured output from the reject handler. */
+export interface RejectOutput {
+  /** Review node ID */
+  id: string;
+  /** URL to the review */
+  url?: string | undefined;
+}
+
+// =============================================================================
+// Handler
+// =============================================================================
+
+/**
+ * Request changes on a pull request.
+ *
+ * Submits a REQUEST_CHANGES review via the GitHub REST API. A body is
+ * required by GitHub for change-request reviews.
+ *
+ * @param input - PR number, repo, body
+ * @param ctx - Handler context with config, db, logger
+ * @returns Result with review ID and URL on success
+ */
+export async function rejectHandler(
+  input: RejectInput,
+  ctx: HandlerContext
+): Promise<Result<RejectOutput, Error>> {
+  const authResult = await detectAuth(ctx.config.github_token);
+  if (authResult.isErr()) {
+    return Result.err(
+      new AuthError({ message: authResult.error.message })
+    );
+  }
+
+  const { GitHubClient } = await import("../github");
+  const client = new GitHubClient(authResult.value.token);
+
+  const parts = input.repo.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return Result.err(
+      new ValidationError({ message: `Invalid repo format: ${input.repo}` })
+    );
+  }
+  const [owner, repo] = parts;
+  const reviewResult = await client.addReview(
+    owner,
+    repo,
+    input.pr,
+    "request-changes",
+    input.body
+  );
+
+  if (reviewResult.isErr()) {
+    return Result.err(reviewResult.error);
+  }
+
+  const review = reviewResult.value;
+  if (!review) {
+    return Result.ok({ id: "" });
+  }
+
+  return Result.ok({
+    id: review.id,
+    ...(review.url && { url: review.url }),
+  });
+}


### PR DESCRIPTION
## Summary
- Extract `approveHandler`, `rejectHandler`, `editHandler` to core
- Simplest handlers: validate input → call GitHubClient method → return Result
- Each handler is ~50-80 lines with typed input/output (FIRE-7)

## Test plan
- [x] `bun run check` passes
- [x] `bun test` passes (288 tests)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extracts PR mutation handlers (`approveHandler`, `rejectHandler`, `editHandler`) from CLI to core package for code reuse.

- `approve.ts` and `reject.ts` are clean, straightforward implementations
- `edit.ts` has critical bugs in comment editing:
  - `extractNumericId()` won't correctly decode GitHub node IDs (needs base64 decoding)
  - Missing fallback to `entry.database_id` field
  - Missing support for `review_comment` subtype (only handles issue comments)
- The CLI implementation (`apps/cli/src/commands/edit.ts`) has the correct approach that should be replicated

<h3>Confidence Score: 2/5</h3>

- Not safe to merge - critical bugs in edit handler will cause runtime failures
- The `editHandler` has three critical bugs that will cause failures when editing comments: incorrect numeric ID extraction, missing database_id fallback, and missing review_comment support. The approve and reject handlers are fine.
- packages/core/src/handlers/edit.ts requires fixes before merging

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/handlers/approve.ts | New approve handler - validates input, authenticates, and submits APPROVE review. Clean implementation, no issues found. |
| packages/core/src/handlers/reject.ts | New reject handler - validates input, authenticates, and submits REQUEST_CHANGES review. Clean implementation, no issues found. |
| packages/core/src/handlers/edit.ts | New edit handler - has critical bug in extractNumericId() and missing review_comment handling. The comment editing logic will fail for entries without database_id field. |
| packages/core/src/handlers/index.ts | Export file - adds exports for approve, reject, and edit handlers. No issues. |

</details>


</details>


[![Fix All in Claude Code](https://img.shields.io/badge/Fix_All_in_claude-black?logo=claude&logoColor=%23D97706)](https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fcore%2Fsrc%2Fhandlers%2Fedit.ts%3A202-209%0A%60extractNumericId%28entry.id%29%60%20won't%20work%20reliably%20-%20%60entry.database_id%60%20is%20optional%20and%20not%20always%20populated.%20Should%20use%20the%20same%20approach%20as%20%60apps%2Fcli%2Fsrc%2Fcommands%2Fedit.ts%3A168-175%60%20which%20tries%20%60entry.database_id%60%20first%2C%20then%20falls%20back%20to%20base64%20decoding%3A%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20Prefer%20stored%20database_id%20%28synced%20from%20GitHub%20API%29%0A%20%20const%20numericId%20%3D%20entry.database_id%20%3F%3F%20extractNumericId%28entry.id%29%3B%0A%20%20if%20%28!numericId%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fcore%2Fsrc%2Fhandlers%2Fedit.ts%3A222-231%0A%60extractNumericId%28%29%60%20is%20too%20simplistic%20-%20GitHub%20node%20IDs%20are%20base64-encoded%20%28e.g.%2C%20%22IC_kwDO...%22%29.%20The%20regex%20won't%20extract%20the%20numeric%20ID%20correctly.%20Use%20the%20base64%20decoding%20approach%20from%20%60apps%2Fcli%2Fsrc%2Fcommands%2Fedit.ts%3A148-162%60%3A%0A%0A%60%60%60suggestion%0Afunction%20extractNumericId%28id%3A%20string%29%3A%20number%20%7C%20null%20%7B%0A%20%20%2F%2F%20Try%20direct%20numeric%0A%20%20const%20num%20%3D%20Number%28id%29%3B%0A%20%20if%20%28!Number.isNaN%28num%29%20%26%26%20num%20%3E%200%29%20%7B%0A%20%20%20%20return%20num%3B%0A%20%20%7D%0A%20%20%2F%2F%20Try%20base64%20decoding%20for%20GraphQL%20node%20IDs%0A%20%20try%20%7B%0A%20%20%20%20const%20decoded%20%3D%20Buffer.from%28id%2C%20%22base64%22%29.toString%28%22utf8%22%29%3B%0A%20%20%20%20const%20matches%20%3D%20decoded.match%28%2F%5Cd%2B%2Fg%29%3B%0A%20%20%20%20const%20last%20%3D%20matches%3F.at%28-1%29%3B%0A%20%20%20%20return%20last%20%3F%20Number%28last%29%20%3A%20null%3B%0A%20%20%7D%20catch%20%7B%0A%20%20%20%20return%20null%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fcore%2Fsrc%2Fhandlers%2Fedit.ts%3A211-214%0AOnly%20handles%20issue%20comments%20-%20missing%20%60review_comment%60%20support.%20Check%20%60entry.subtype%60%20and%20call%20%60client.editReviewComment%28%29%60%20for%20review%20comments%20%28see%20%60apps%2Fcli%2Fsrc%2Fcommands%2Fedit.ts%3A622-626%60%29%0A%0A&repo=outfitter-dev%2Ffirewatch) [![Fix All in Codex](https://img.shields.io/badge/Fix_All_in_codex-black?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0yMi4yODIgOS44MjFhNS45ODUgNS45ODUgMCAwIDAtLjUxNi00LjkxIDYuMDQ2IDYuMDQ2IDAgMCAwLTYuNTEtMi45QTYuMDY1IDYuMDY1IDAgMCAwIDQuOTgxIDQuMThhNS45ODUgNS45ODUgMCAwIDAtMy45OTggMi45IDYuMDQ2IDYuMDQ2IDAgMCAwIC43NDMgNy4wOTcgNS45OCA1Ljk4IDAgMCAwIC41MSA0LjkxMSA2LjA1MSA2LjA1MSAwIDAgMCA2LjUxNSAyLjlBNS45ODUgNS45ODUgMCAwIDAgMTMuMjYgMjRhNi4wNTYgNi4wNTYgMCAwIDAgNS43NzItNC4yMDYgNS45OSA1Ljk5IDAgMCAwIDMuOTk3LTIuOSA2LjA1NiA2LjA1NiAwIDAgMC0uNzQ3LTcuMDczek0xMy4yNiAyMi40M2E0LjQ3NiA0LjQ3NiAwIDAgMS0yLjg3Ni0xLjA0bC4xNDEtLjA4MSA0Ljc3OS0yLjc1OGEuNzk1Ljc5NSAwIDAgMCAuMzkyLS42ODF2LTYuNzM3bDIuMDIgMS4xNjhhLjA3MS4wNzEgMCAwIDEgLjAzOC4wNTJ2NS41ODNhNC41MDQgNC41MDQgMCAwIDEtNC40OTQgNC40OTR6TTMuNiAxOC4zMDRhNC40NyA0LjQ3IDAgMCAxLS41MzUtMy4wMTRsLjE0Mi4wODUgNC43ODMgMi43NTlhLjc3MS43NzEgMCAwIDAgLjc4IDBsNS44NDMtMy4zNjl2Mi4zMzJhLjA4LjA4IDAgMCAxLS4wMzMuMDYyTDkuNzQgMTkuOTVhNC41IDQuNSAwIDAgMS02LjE0LTEuNjQ2ek0yLjM0IDcuODk2YTQuNDg1IDQuNDg1IDAgMCAxIDIuMzY2LTEuOTczVjExLjZhLjc2Ni43NjYgMCAwIDAgLjM4OC42NzZsNS44MTUgMy4zNTUtMi4wMiAxLjE2OGEuMDc2LjA3NiAwIDAgMS0uMDcxIDBsLTQuODMtMi43ODZBNC41MDQgNC41MDQgMCAwIDEgMi4zNCA3Ljg3MnptMTYuNTk3IDMuODU1bC01LjgzMy0zLjM4N0wxNS4xMTkgNy4yYS4wNzYuMDc2IDAgMCAxIC4wNzEgMGw0LjgzIDIuNzkxYTQuNDk0IDQuNDk0IDAgMCAxLS42NzYgOC4xMDV2LTUuNjc4YS43OS43OSAwIDAgMC0uNDA3LS42Njd6bTIuMDEtMy4wMjNsLS4xNDEtLjA4NS00Ljc3NC0yLjc4MmEuNzc2Ljc3NiAwIDAgMC0uNzg1IDBMOS40MDkgOS4yM1Y2Ljg5N2EuMDY2LjA2NiAwIDAgMSAuMDI4LS4wNjFsNC44My0yLjc4N2E0LjUgNC41IDAgMCAxIDYuNjggNC42NnptLTEyLjY0IDQuMTM1bC0yLjAyLTEuMTY0YS4wOC4wOCAwIDAgMS0uMDM4LS4wNTdWNi4wNzVhNC41IDQuNSAwIDAgMSA3LjM3NS0zLjQ1M2wtLjE0Mi4wOEw4LjcwNCA1LjQ2YS43OTUuNzk1IDAgMCAwLS4zOTMuNjgxem0xLjA5Ny0yLjM2NWwyLjYwMi0xLjUgMi42MDcgMS41djIuOTk5bC0yLjU5NyAxLjUtMi42MDctMS41eiIvPjwvc3ZnPg==&logoColor=white)](https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fcore%2Fsrc%2Fhandlers%2Fedit.ts%3A202-209%0A%60extractNumericId%28entry.id%29%60%20won't%20work%20reliably%20-%20%60entry.database_id%60%20is%20optional%20and%20not%20always%20populated.%20Should%20use%20the%20same%20approach%20as%20%60apps%2Fcli%2Fsrc%2Fcommands%2Fedit.ts%3A168-175%60%20which%20tries%20%60entry.database_id%60%20first%2C%20then%20falls%20back%20to%20base64%20decoding%3A%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20Prefer%20stored%20database_id%20%28synced%20from%20GitHub%20API%29%0A%20%20const%20numericId%20%3D%20entry.database_id%20%3F%3F%20extractNumericId%28entry.id%29%3B%0A%20%20if%20%28!numericId%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fcore%2Fsrc%2Fhandlers%2Fedit.ts%3A222-231%0A%60extractNumericId%28%29%60%20is%20too%20simplistic%20-%20GitHub%20node%20IDs%20are%20base64-encoded%20%28e.g.%2C%20%22IC_kwDO...%22%29.%20The%20regex%20won't%20extract%20the%20numeric%20ID%20correctly.%20Use%20the%20base64%20decoding%20approach%20from%20%60apps%2Fcli%2Fsrc%2Fcommands%2Fedit.ts%3A148-162%60%3A%0A%0A%60%60%60suggestion%0Afunction%20extractNumericId%28id%3A%20string%29%3A%20number%20%7C%20null%20%7B%0A%20%20%2F%2F%20Try%20direct%20numeric%0A%20%20const%20num%20%3D%20Number%28id%29%3B%0A%20%20if%20%28!Number.isNaN%28num%29%20%26%26%20num%20%3E%200%29%20%7B%0A%20%20%20%20return%20num%3B%0A%20%20%7D%0A%20%20%2F%2F%20Try%20base64%20decoding%20for%20GraphQL%20node%20IDs%0A%20%20try%20%7B%0A%20%20%20%20const%20decoded%20%3D%20Buffer.from%28id%2C%20%22base64%22%29.toString%28%22utf8%22%29%3B%0A%20%20%20%20const%20matches%20%3D%20decoded.match%28%2F%5Cd%2B%2Fg%29%3B%0A%20%20%20%20const%20last%20%3D%20matches%3F.at%28-1%29%3B%0A%20%20%20%20return%20last%20%3F%20Number%28last%29%20%3A%20null%3B%0A%20%20%7D%20catch%20%7B%0A%20%20%20%20return%20null%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fcore%2Fsrc%2Fhandlers%2Fedit.ts%3A211-214%0AOnly%20handles%20issue%20comments%20-%20missing%20%60review_comment%60%20support.%20Check%20%60entry.subtype%60%20and%20call%20%60client.editReviewComment%28%29%60%20for%20review%20comments%20%28see%20%60apps%2Fcli%2Fsrc%2Fcommands%2Fedit.ts%3A622-626%60%29%0A%0A&repo=outfitter-dev%2Ffirewatch)

<sub>Last reviewed commit: 8889f7c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->