### PR TITLE
feat(cli): adopt @outfitter/cli with createCLI() entry point

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -21,11 +21,16 @@
     "check": "bunx tsc -b"
   },
   "dependencies": {
+    "@outfitter/cli": "^0.5.2",
+    "@outfitter/config": "^0.3.3",
     "@outfitter/firewatch-core": "workspace:*",
     "@outfitter/firewatch-mcp": "workspace:*",
     "@outfitter/firewatch-shared": "workspace:*",
-    "commander": "^13.0.0",
-    "ora": "^8.1.1"
+    "@outfitter/schema": "^0.2.2",
+    "@outfitter/types": "^0.2.3",
+    "commander": "^14.0.0",
+    "ora": "^8.1.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/bun": "^1.3.6"


### PR DESCRIPTION
## Summary
- Replace raw `new Command()` with `createCLI()` from `@outfitter/cli`
- Global `--json` flag with `OUTFITTER_JSON` env var bridge (no per-command `--json` needed)
- Subcommands registered via `cli.register()` (chainable)
- Upgrade Commander from v13 to v14 (required by `@outfitter/cli` types)
- Update `shouldOutputJson()` to check `OUTFITTER_JSON` env var (FIRE-9)

## Test plan
- [x] `bun run check` passes
- [x] `bun test` passes (298 tests)
- [x] `bun apps/cli/bin/fw.ts status --short` smoke test

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully migrates the CLI from raw Commander.js to the `@outfitter/cli` wrapper with `createCLI()`. The changes introduce a global `--json` flag that sets `OUTFITTER_JSON` env var, eliminating the need for per-command `--json` options on the root command. The implementation correctly updates `shouldOutputJson()` to check this new env var while maintaining backwards compatibility with legacy `FIREWATCH_JSONL` and `FIREWATCH_JSON` variables.

Key changes:
- Adopted `createCLI()` entry point with chainable `cli.register()` for subcommands
- Upgraded Commander from v13 to v14 (required by `@outfitter/cli` types)
- Removed hidden `--json` option from root command (now provided globally by `createCLI`)
- Updated `shouldOutputJson()` with proper precedence: explicit flags → `OUTFITTER_JSON` → legacy env vars → TTY detection
- Changed entry point from `program.parseAsync()` to `cli.parse()`

The refactoring is clean, maintains API compatibility, and follows the described migration plan.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The refactoring is well-structured, maintains backwards compatibility, and aligns with the stated test plan (bun run check passes, bun test passes, smoke test completed). The changes are isolated to CLI initialization and flag handling, with proper env var bridging for the global --json flag.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/package.json | Added `@outfitter/cli` and upgraded Commander v13 -> v14, plus supporting packages (`@outfitter/config`, `@outfitter/schema`, `@outfitter/types`, `zod`) |
| apps/cli/src/index.ts | Replaced `new Command()` with `createCLI()`, removed hidden `--json` from root (now global), chainable `cli.register()` for subcommands, updated to `cli.parse()` |
| apps/cli/src/utils/tty.ts | Updated `shouldOutputJson()` to check `OUTFITTER_JSON` env var (set by `createCLI` global `--json`), with proper precedence and backwards compatibility for legacy env vars |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User runs: fw --json query] --> B[createCLI preAction hook]
    B --> C[Sets OUTFITTER_JSON=1]
    C --> D[cli.parse executes command]
    D --> E[Command calls shouldOutputJson]
    E --> F{Check precedence}
    F -->|1. Explicit flag| G[--jsonl or --no-jsonl?]
    G -->|Yes| H[Return true/false]
    G -->|No| I{Check options.json === true?}
    I -->|Yes| J[Return true]
    I -->|No| K{Check OUTFITTER_JSON?}
    K -->|=1| L[Return true]
    K -->|=0| M[Return false]
    K -->|Not set| N{Check legacy env vars}
    N -->|FIREWATCH_JSONL/JSON| O[Return based on value]
    N -->|Not set| P{Check TTY}
    P -->|Is TTY| Q[Return false - human]
    P -->|Not TTY| R[Return true - JSONL]
```
</details>


<sub>Last reviewed commit: abcf1dd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->