### PR TITLE
feat(mcp): adopt @outfitter/mcp with createMcpServer() and defineTool()

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -23,12 +23,16 @@
     "check": "bunx tsc -b"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@outfitter/config": "^0.3.0",
+    "@outfitter/contracts": "^0.4.1",
     "@outfitter/firewatch-core": "workspace:*",
     "@outfitter/firewatch-shared": "workspace:*",
+    "@outfitter/logging": "^0.4.1",
+    "@outfitter/mcp": "^0.4.2",
     "zod": "^4.3.5"
   },
   "devDependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
     "@types/bun": "^1.3.6"
   }
 }

--- a/apps/mcp/tests/integration.test.ts
+++ b/apps/mcp/tests/integration.test.ts
@@ -11,6 +11,7 @@ import {
   type FirewatchEntry,
   type PRMetadata,
 } from "@outfitter/firewatch-core";
+import { createSdkServer } from "@outfitter/mcp";
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -102,12 +103,13 @@ afterAll(async () => {
 });
 
 async function callTool(name: string, args: Record<string, unknown>) {
-  const server = createServer();
+  const mcpServer = createServer();
+  const sdkServer = createSdkServer(mcpServer);
   const [clientTransport, serverTransport] =
     InMemoryTransport.createLinkedPair();
   const client = new Client({ name: "firewatch-test", version: "0.0.0" });
 
-  await server.connect(serverTransport);
+  await sdkServer.connect(serverTransport);
   await client.connect(clientTransport);
 
   const result = await client.callTool({
@@ -116,7 +118,7 @@ async function callTool(name: string, args: Record<string, unknown>) {
   });
 
   await client.close();
-  await server.close();
+  await sdkServer.close();
 
   return result;
 }


### PR DESCRIPTION
## Summary
- Replace `McpServer`/`StdioServerTransport` with `createMcpServer()`/`connectStdio()`
- All 6 tools use `defineTool()` with `TOOL_ANNOTATIONS` presets (readOnly, destructive)
- `adaptHandler()` bridges domain errors to `OutfitterError` for JSON-RPC code mapping
- Auth-gated write tools registered after `connectStdio()` with auto `tools/list_changed`
- `@modelcontextprotocol/sdk` retained as devDependency for types (FIRE-11)

## Test plan
- [x] `bun run check` passes
- [x] `bun test` passes (298 tests)
- [x] `bun apps/mcp/bin/fw-mcp.ts` starts without error

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Migrated the MCP server from direct `@modelcontextprotocol/sdk` usage to the `@outfitter/mcp` abstraction layer. The class-based `FirewatchMCPServer` is replaced with functional composition using `createMcpServer()`, `defineTool()`, and `adaptHandler()`. All 6 tools now use standardized `TOOL_ANNOTATIONS` presets for readOnly/write/destructive categories, and error handling is unified through `adaptHandler()` which bridges domain errors to `Result<T, OutfitterError>` for proper JSON-RPC error code mapping. The SDK is retained as a devDependency for type compatibility (FIRE-11).

Key changes:
- Renamed schema exports from `*ParamsShape` to `*ParamsSchema` for consistency
- Auth-gated write tools now registered after `connectStdio()` with auto `notifyToolsChanged()`
- Test helper updated to use `createSdkServer()` wrapper for SDK compatibility
- All tool handlers wrapped in try/catch with Result-based returns

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-structured refactoring with passing tests
- Clean migration to abstraction layer with comprehensive test coverage (298 tests passing). The refactoring maintains all existing functionality while improving code organization through functional composition. Error handling is properly unified, and the SDK compatibility is preserved for tests.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/mcp/package.json | Moved `@modelcontextprotocol/sdk` to devDependencies, added new `@outfitter/*` dependencies for the MCP refactor |
| apps/mcp/src/index.ts | Refactored from class-based `FirewatchMCPServer` to functional approach with `createMcpServer()` and `defineTool()`, using `adaptHandler()` to bridge domain errors to Result types |
| apps/mcp/tests/integration.test.ts | Updated test helper to use `createSdkServer()` wrapper for SDK compatibility with InMemoryTransport |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[run] --> B[initializeServer]
    B --> C[createMcpServer]
    B --> D[Create AuthGateState]
    B --> E[Register Base Tools]
    
    E --> E1[defineQueryTool]
    E --> E2[defineStatusTool]
    E --> E3[defineDoctorTool]
    E --> E4[defineHelpTool]
    
    E1 --> F[defineTool + adaptHandler]
    E2 --> F
    E3 --> F
    E4 --> F
    
    A --> G[connectStdio]
    A --> H[verifyAuthAndEnableWriteTools]
    
    H --> I{Auth Success?}
    I -->|Yes| J[registerWriteTools]
    I -->|No| K[Return Error]
    
    J --> J1[definePrTool]
    J --> J2[defineFbTool]
    
    J1 --> L[defineTool + adaptHandler]
    J2 --> L
    
    J --> M[notifyToolsChanged]
    
    F --> N[Result.ok/Result.err]
    L --> N
```
</details>


<sub>Last reviewed commit: 0e54a57</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->